### PR TITLE
Implement Github actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,107 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  merge_group:
+    types: [ "checks_requested" ]
+
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build Rust tests
+        run: cargo test --no-default-features --no-run
+      - name: Run Rust tests
+        run: cargo test --no-default-features
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e  ".[test]"
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 python/ --count --select=E9,F63,F7,F82 --show-source --statistics
+      - name: Lint with Black
+        uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "python/"
+      - name: Test with pytest
+        run: |
+          pytest python/tst/unit
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ github.job }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Lint with clippy
+        run: cargo clippy --all-targets --all-features

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ S3Dataset is a tool which allows Python code to interface with a performant S3 c
 When you make changes to the Rust code, you need to run `pip install -e .` before changes will be viewable from 
 Python. It's probably worth creating a shell script for this and adding it as part of the pre-build step.
 
+### Making a commit
+
+Our CI uses `clippy` to lint Rust code changes. Use `cargo clippy --all-targets --all-features` to lint Rust before
+pushing new Rust commits.
+
+For Python code changes, run 
+```bash
+black --verbose python/
+flake8 python/ --count --select=E9,F63,F7,F82 --show-source --statistics
+```
+ to lint.
+
 ## Debugging
 
 Either a Python or GDB style debugger will be useful here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest"
+    "pytest",
+    "flake8",
+    "black"
 ]
 
 [tool.setuptools.packages]

--- a/python/src/s3dataset/__init__.py
+++ b/python/src/s3dataset/__init__.py
@@ -4,5 +4,5 @@ from s3dataset._logger_patch import _install_trace_logging
 _install_trace_logging()
 
 __all__ = [
-    "LOG_TRACE"
+    "LOG_TRACE",
 ]

--- a/python/src/s3dataset/_s3dataset.pyi
+++ b/python/src/s3dataset/_s3dataset.pyi
@@ -1,26 +1,39 @@
 from typing import List, Optional
 
-
 # This interface is unstable!
-
 
 class MountpointS3Client:
     region: str
     throughput_target_gbps: float
     part_size: int
 
-    def __init__(self, region: str, throughput_target_gbps: float = 10.0, part_size: int = 8*1024*1024, profile: str = None, no_sign_request: bool = False): ...
+    def __init__(
+        self,
+        region: str,
+        throughput_target_gbps: float = 10.0,
+        part_size: int = 8 * 1024 * 1024,
+        profile: str = None,
+        no_sign_request: bool = False,
+    ): ...
     def get_object(self, bucket: str, key: str) -> GetObjectStream: ...
-    def put_object(self, bucket: str, key: str, storage_class: Optional[str] = None) -> PutObjectStream: ...
-    def list_objects(self, bucket: str, prefix: str = "", delimiter: str = "", max_keys: int = 1000) -> ListObjectStream: ...
-
+    def put_object(
+        self, bucket: str, key: str, storage_class: Optional[str] = None
+    ) -> PutObjectStream: ...
+    def list_objects(
+        self, bucket: str, prefix: str = "", delimiter: str = "", max_keys: int = 1000
+    ) -> ListObjectStream: ...
 
 class MockMountpointS3Client:
-    def __init__(self, region: str, bucket: str, throughput_target_gbps: float = 10.0, part_size: int = 8*1024*1024): ...
+    def __init__(
+        self,
+        region: str,
+        bucket: str,
+        throughput_target_gbps: float = 10.0,
+        part_size: int = 8 * 1024 * 1024,
+    ): ...
     def create_mocked_client(self) -> MountpointS3Client: ...
     def add_object(self, key: str, data: bytes) -> None: ...
     def remove_object(self, key: str) -> None: ...
-
 
 class GetObjectStream:
     bucket: str
@@ -30,18 +43,15 @@ class GetObjectStream:
     def __next__(self) -> bytes: ...
     def tell(self) -> int: ...
 
-
 class PutObjectStream:
     bucket: str
     key: str
     def write(self, data: bytes) -> None: ...
     def close(self) -> None: ...
 
-
 class RestoreStatus:
     in_progress: bool
     expiry: Optional[int]
-
 
 class ObjectInfo:
     key: str
@@ -51,18 +61,15 @@ class ObjectInfo:
     storage_class: Optional[str]
     restore_status: Optional[RestoreStatus]
 
-
 class ListObjectResult:
     object_info: List[ObjectInfo]
     common_prefixes: List[str]
-
 
 class ListObjectStream:
     bucket: str
 
     def __iter__(self) -> ListObjectStream: ...
     def __next__(self) -> ListObjectResult: ...
-
 
 class S3DatasetException(Exception):
     pass

--- a/python/src/s3dataset/s3dataset_base.py
+++ b/python/src/s3dataset/s3dataset_base.py
@@ -80,7 +80,9 @@ class S3DatasetBase:
         client: MountpointS3Client, bucket_key_pairs: Iterable[Tuple[str, str]]
     ) -> Iterable[S3Object]:
         for bucket, key in bucket_key_pairs:
-            yield S3Object(bucket, key, get_stream=lambda: client.get_object(bucket, key))
+            yield S3Object(
+                bucket, key, get_stream=lambda: client.get_object(bucket, key)
+            )
 
     @staticmethod
     def _list_objects_for_bucket(

--- a/python/tst/unit/test_mountpoint_s3_client.py
+++ b/python/tst/unit/test_mountpoint_s3_client.py
@@ -101,6 +101,9 @@ def test_get_object_iterates_once():
     returned_data = b"".join(stream)
     assert returned_data == b"data"
 
+    returned_data = b"".join(stream)
+    assert returned_data == b""
+
 
 def test_get_object_throws_stop_iteration():
     mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
@@ -176,7 +179,7 @@ def test_list_objects_with_prefix(prefix: str, keys: Set[str], expected_keys: Se
     [
         (b"Hello, world!", 2000),
         (b"MultiPartUpload", 2),
-        (b"", 2000)
+        (b"", 2000),
     ],
 )
 def test_put_object(data_to_write: bytes, part_size: int):

--- a/python/tst/unit/test_s3object.py
+++ b/python/tst/unit/test_s3object.py
@@ -52,9 +52,9 @@ def test_s3object_invalid_creation(bucket, key):
 @pytest.mark.parametrize(
     "stream",
     [
-        ([b"1", b"2", b"3"],),
-        ([],),
-        ([b"hello!"],)
+        [b"1", b"2", b"3"],
+        [],
+        [b"hello!"],
     ],
 )
 def test_s3object_prefetch(stream):

--- a/rust/src/list_object_stream.rs
+++ b/rust/src/list_object_stream.rs
@@ -72,11 +72,7 @@ impl ListObjectStream {
             slf.complete = true;
         }
 
-        let objects = results
-            .objects
-            .into_iter()
-            .map(|obj| PyObjectInfo::new(obj))
-            .collect();
+        let objects = results.objects.into_iter().map(PyObjectInfo::new).collect();
 
         Ok(Some(PyListObjectResult::new(
             objects,


### PR DESCRIPTION
Creates a Github actions workflow for running unit tests and code linting when merging to main branch.

Unit tests for Rust are ran with `cargo test --no-default-features`
Unit tests for Python are ran with `pytest python/tst/unit`
Code linting for Rust is done with `cargo clippy`
Code linting for Python is done with both flake8: `flake8 python/ --count --select=E9,F63,F7,F82 --show-source --statistics`  and Black: `black --check --verbose python/`