### PR TITLE
Make `S3Object` lazily download from S3

### DIFF
--- a/python/src/s3dataset/s3dataset_base.py
+++ b/python/src/s3dataset/s3dataset_base.py
@@ -1,7 +1,7 @@
 from typing import Iterable, Union, Tuple
-from s3dataset.s3object import S3Object
-from s3dataset._s3dataset import MountpointS3Client
 
+from s3dataset._s3dataset import MountpointS3Client
+from s3dataset.s3object import S3Object
 
 """
 s3dataset_base.py
@@ -80,7 +80,7 @@ class S3DatasetBase:
         client: MountpointS3Client, bucket_key_pairs: Iterable[Tuple[str, str]]
     ) -> Iterable[S3Object]:
         for bucket, key in bucket_key_pairs:
-            yield S3Object(bucket, key, stream=client.get_object(bucket, key))
+            yield S3Object(bucket, key, get_stream=lambda: client.get_object(bucket, key))
 
     @staticmethod
     def _list_objects_for_bucket(
@@ -95,7 +95,7 @@ class S3DatasetBase:
                     bucket,
                     object_info.key,
                     object_info,
-                    client.get_object(bucket, object_info.key),
+                    lambda: client.get_object(bucket, object_info.key),
                 )
 
     @staticmethod

--- a/python/src/s3dataset/s3object.py
+++ b/python/src/s3dataset/s3object.py
@@ -1,4 +1,6 @@
 import io
+from typing import Callable
+
 from s3dataset._s3dataset import ObjectInfo, GetObjectStream
 
 """
@@ -13,17 +15,23 @@ class S3Object(io.BufferedIOBase):
         bucket: str,
         key: str,
         object_info: ObjectInfo = None,
-        stream: GetObjectStream = None,
+        get_stream: Callable[[], GetObjectStream] = None,
     ):
         if not bucket:
             raise ValueError("Bucket should be specified")
         self.bucket = bucket
         self.key = key
         self.object_info = object_info
-        self.stream = stream
+        self._get_stream = get_stream
+        self._stream = None
+
+    def prefetch(self):
+        if self._stream is None:
+            self._stream = self._get_stream()
 
     # TODO: Support multiple sizes
     def read(self, size=-1):
         if size != -1:
             raise NotImplementedError()
-        return b"".join(self.stream)
+        self.prefetch()
+        return b"".join(self._stream)

--- a/python/tst/unit/test_s3dataset_base.py
+++ b/python/tst/unit/test_s3dataset_base.py
@@ -1,8 +1,7 @@
 import logging
-from typing import Iterable, Union
+from typing import Iterable, Union, Sequence
 
 import pytest
-
 from pytest import fail
 
 from s3dataset._s3dataset import (
@@ -10,7 +9,6 @@ from s3dataset._s3dataset import (
     MockMountpointS3Client,
     MountpointS3Client,
 )
-
 from s3dataset.s3dataset_base import S3DatasetBase, _parse_s3_uri
 
 logging.basicConfig(
@@ -89,7 +87,7 @@ def test_s3dataset_base_parse_s3_uri_fail(uri, error_msg):
     "keys, expected_index",
     [([], 0), (["obj1", "obj2", "obj3", "test"], 3)],
 )
-def test_objects_to_s3objects(keys: Iterable[str], expected_index: int):
+def test_objects_to_s3objects(keys: Sequence[str], expected_index: int):
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, keys)
     bucket_key_pairs = [(TEST_BUCKET, key) for key in keys]
     objects = S3DatasetBase._bucket_keys_to_s3objects(mock_client, bucket_key_pairs)
@@ -99,7 +97,7 @@ def test_objects_to_s3objects(keys: Iterable[str], expected_index: int):
         assert object.bucket == TEST_BUCKET
         assert object.key == keys[index]
         assert object.object_info is None
-        assert object.stream is not None
+        assert object._get_stream is not None
     assert index == expected_index
 
 
@@ -111,7 +109,7 @@ def test_objects_to_s3objects(keys: Iterable[str], expected_index: int):
         ("obj", ["obj1", "obj2", "obj3", "test", "test2"], 2),
     ],
 )
-def test_list_objects_for_bucket(prefix: str, keys: Iterable[str], expected_index: int):
+def test_list_objects_for_bucket(prefix: str, keys: Sequence[str], expected_index: int):
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, keys)
     objects = S3DatasetBase._list_objects_for_bucket(mock_client, TEST_BUCKET, prefix)
     for index, object in enumerate(objects):
@@ -120,7 +118,7 @@ def test_list_objects_for_bucket(prefix: str, keys: Iterable[str], expected_inde
         assert object.key == keys[index]
         assert object.object_info is not None
         assert object.object_info.key == keys[index]
-        assert object.stream is not None
+        assert object._get_stream is not None
     assert index == expected_index
 
 

--- a/python/tst/unit/test_s3iterable_dataset.py
+++ b/python/tst/unit/test_s3iterable_dataset.py
@@ -1,6 +1,6 @@
-import pytest
+from typing import Iterable, Callable, Union, Sequence
 
-from typing import Iterable, Callable, Union
+import pytest
 
 from s3dataset.s3iterable_dataset import S3IterableDataset
 from s3dataset.s3object import S3Object
@@ -87,7 +87,7 @@ def test_s3iterable_dataset_creation_from_objects_with_region(
 
 def _test_s3iterable_dataset(
     dataset: S3IterableDataset,
-    expected_keys: Iterable[str],
+    expected_keys: Sequence[str],
     expected_count: int,
     object_info_check: Callable[[S3Object], bool],
 ):
@@ -97,7 +97,10 @@ def _test_s3iterable_dataset(
         assert data.bucket == TEST_BUCKET
         assert data.key == expected_keys[index]
         assert object_info_check(data)
-        for content in data.stream:
+        assert data._stream is None
+        data.prefetch()
+        assert data._stream is not None
+        for content in data._stream:
             expected_content = bytearray(
                 f"{TEST_BUCKET}-{expected_keys[index]}-dummyData".encode("utf-8")
             )

--- a/python/tst/unit/test_s3object.py
+++ b/python/tst/unit/test_s3object.py
@@ -1,8 +1,8 @@
 import logging
+from unittest.mock import Mock
 
 import pytest
 
-from mock import Mock
 from s3dataset._s3dataset import ObjectInfo, GetObjectStream
 from s3dataset.s3object import S3Object
 
@@ -21,22 +21,22 @@ MOCK_STREAM = Mock(GetObjectStream)
 
 
 @pytest.mark.parametrize(
-    "object_info, stream",
+    "object_info, get_stream",
     [
-        (None, None),
-        (MOCK_OBJECT_INFO, None),
-        (None, MOCK_STREAM),
-        (TEST_BUCKET, None),
-        (TEST_BUCKET, ""),
+        (None, lambda: None),
+        (MOCK_OBJECT_INFO, lambda: None),
+        (None, lambda: MOCK_STREAM),
+        (TEST_BUCKET, lambda: None),
+        (TEST_BUCKET, lambda: ""),
     ],
 )
-def test_s3object_creation(object_info, stream):
-    s3object = S3Object(TEST_BUCKET, TEST_KEY, object_info, stream)
+def test_s3object_creation(object_info, get_stream):
+    s3object = S3Object(TEST_BUCKET, TEST_KEY, object_info, get_stream)
     assert s3object
     assert s3object.bucket == TEST_BUCKET
     assert s3object.key == TEST_KEY
     assert s3object.object_info == object_info
-    assert s3object.stream == stream
+    assert s3object._get_stream is get_stream
 
 
 @pytest.mark.parametrize(
@@ -47,3 +47,34 @@ def test_s3object_invalid_creation(bucket, key):
     with pytest.raises(ValueError) as error:
         S3Object(bucket, key)
     assert str(error.value) == "Bucket should be specified"
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [
+        ([b"1", b"2", b"3"],),
+        ([],),
+        ([b"hello!"],)
+    ],
+)
+def test_s3object_prefetch(stream):
+    s3object = S3Object(TEST_BUCKET, TEST_KEY, None, lambda: stream)
+    assert s3object._stream is None
+    s3object.prefetch()
+    assert s3object._stream is stream
+    s3object.prefetch()
+    assert s3object._stream is stream
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [
+        [b"1", b"2", b"3"],
+        [],
+        [b"hello!"],
+    ],
+)
+def test_s3object_read(stream):
+    s3object = S3Object(TEST_BUCKET, TEST_KEY, None, lambda: stream)
+    assert s3object._stream is None
+    assert b"".join(stream) == s3object.read()


### PR DESCRIPTION
*Description of changes:*

`S3Object` previously took a `GetObjectStream` object as its stream, though we've previously identified that `GetObjectStream` starts reading from S3 in the background. To resolve this, we're changing `S3Object` to take a callable of `GetObjectStream` to defer the download until it's requested through the use of a `prefetch` method. 

*Testing:*

Add unit tests for `prefetch` method, and that `read` behaves properly for mock stream data.