### PR TITLE
Add public exports to s3dataset module

### DIFF
--- a/python/src/s3dataset/__init__.py
+++ b/python/src/s3dataset/__init__.py
@@ -2,6 +2,7 @@ from ._logger_patch import TRACE as LOG_TRACE
 from ._logger_patch import _install_trace_logging
 from .s3dataset_base import S3DatasetBase
 from .s3iterable_dataset import S3IterableDataset
+from .s3mapstyle_dataset import S3MapStyleDataset
 from .s3object import S3Object
 
 _install_trace_logging()
@@ -10,5 +11,6 @@ __all__ = [
     "LOG_TRACE",
     "S3Object",
     "S3IterableDataset",
+    "S3MapStyleDataset",
     "S3DatasetBase",
 ]


### PR DESCRIPTION
*Description of changes:*

Adds `S3Object`, `S3IterableDataset`, `S3MapStyleDataset`, and `S3DatasetBase` as exports.

*Testing:*

Manual importing of `from s3dataset import S3Object, S3MapStyleDataset, S3IterableDataset, S3DatasetBase
` and saw that it worked.