### PR TITLE
Add stream_callback for `S3Object`

### DIFF
--- a/python/src/s3dataset/s3object.py
+++ b/python/src/s3dataset/s3object.py
@@ -1,12 +1,18 @@
-import io
-from typing import Callable
+from __future__ import annotations
 
-from s3dataset._s3dataset import ObjectInfo, GetObjectStream
+import io
+from typing import Callable, Iterator
+
+from s3dataset._s3dataset import ObjectInfo
 
 """
 s3_object.py
     File like representation of an S3 object.
 """
+
+
+def _default_callback(s3_object: S3Object, data: bytes) -> None:
+    return None
 
 
 class S3Object(io.BufferedIOBase):
@@ -15,7 +21,8 @@ class S3Object(io.BufferedIOBase):
         bucket: str,
         key: str,
         object_info: ObjectInfo = None,
-        get_stream: Callable[[], GetObjectStream] = None,
+        get_stream: Callable[[], Iterator[bytes]] = None,
+        stream_callback: Callable[[S3Object, bytes], None] = None,
     ):
         if not bucket:
             raise ValueError("Bucket should be specified")
@@ -24,10 +31,16 @@ class S3Object(io.BufferedIOBase):
         self.object_info = object_info
         self._get_stream = get_stream
         self._stream = None
+        self._stream_callback = stream_callback or _default_callback
 
     def prefetch(self):
         if self._stream is None:
-            self._stream = self._get_stream()
+            self._stream = self._wrap_stream(self._get_stream())
+
+    def _wrap_stream(self, stream: Iterator[bytes]) -> Iterator[bytes]:
+        for data in stream:
+            self._stream_callback(self, data)
+            yield data
 
     # TODO: Support multiple sizes
     def read(self, size=-1):


### PR DESCRIPTION
*Description of changes:*

Add stream_callback for `S3Object` which is used to provide a callback interface whenever we receive data from S3.

This callback can be used to profile how fast we're able to pull data from S3, assuming we don't prefetch. This would be at a higher granularity than the simpler approach of just seeing how long it takes to read a specific object.

*Testing:*

Adds additional assertions to existing unit tests.