### PR TITLE
Add `e2e` package list for running end to end tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ test = [
     "black"
 ]
 
+e2e = [
+    "torchdata",
+    "torchvision",
+    "Pillow"
+]
+
 [tool.setuptools.packages]
 # Pure Python packages/modules
 find = { where = ["python/src", "python/tst"] }

--- a/python/tst/e2e/test_e2e_s3datasets.py
+++ b/python/tst/e2e/test_e2e_s3datasets.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 import pytest
 import torch
-import torchdata
+import torchdata  # FIXME: torchdata is deprecated.
 import torchvision
 from PIL import Image
 from torch import Tensor
@@ -13,10 +13,9 @@ from torch.utils.data.datapipes.utils.common import StreamWrapper
 from torchdata.datapipes.iter import IterableWrapper, IterDataPipe
 
 from s3dataset._s3dataset import MountpointS3Client
-from s3dataset.s3object import S3Object
 from s3dataset.s3iterable_dataset import S3IterableDataset
 from s3dataset.s3mapstyle_dataset import S3MapStyleDataset
-
+from s3dataset.s3object import S3Object
 
 E2E_TEST_BUCKET = "dataset-it-bucket"
 E2E_BUCKET_PREFIX = "e2e-tests/images-10/img"


### PR DESCRIPTION
*Description of changes:*

Adds dependency list for packages used in `e2e` tests.

*Testing:*

Ran `pip install -e ".[e2e]"` and tests passed. Previously tests did not pass.