### PR TITLE
Add pickle support for `S3IterableDataset`

### DIFF
--- a/s3dataset/src/s3dataset/_s3_bucket_iterable.py
+++ b/s3dataset/src/s3dataset/_s3_bucket_iterable.py
@@ -1,0 +1,75 @@
+from functools import partial
+from itertools import chain
+from typing import Iterator, List
+
+from s3dataset_s3_client._s3dataset import (
+    MountpointS3Client,
+    ObjectInfo,
+    ListObjectResult,
+    ListObjectStream,
+)
+
+from s3dataset_s3_client import S3Object
+
+
+class S3BucketIterable:
+    def __init__(self, client: MountpointS3Client, bucket: str, prefix: str):
+        self._client = client
+        self._bucket = bucket
+        self._prefix = prefix
+
+    def __iter__(self):
+        # This allows us to iterate multiple times by re-creating the `_list_stream`
+        return iter(S3BucketIterator(self._client, self._bucket, self._prefix))
+
+
+class S3BucketIterator:
+    def __init__(self, client: MountpointS3Client, bucket: str, prefix: str):
+        self._client = client
+        self._bucket = bucket
+        self._list_stream = _PickleableListObjectStream(client, bucket, prefix)
+
+    def __iter__(self) -> Iterator[S3Object]:
+        return map(
+            self._create_s3_object,
+            chain.from_iterable(map(_extract_object_info, self._list_stream)),
+        )
+
+    def _create_s3_object(self, object_info: ObjectInfo):
+        return S3Object(
+            self._bucket,
+            object_info.key,
+            object_info,
+            get_stream=partial(self._client.get_object, self._bucket, object_info.key),
+        )
+
+
+class _PickleableListObjectStream:
+    def __init__(self, client: MountpointS3Client, bucket: str, prefix: str):
+        self._client = client
+        self._list_stream = iter(client.list_objects(bucket, prefix))
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> ListObjectResult:
+        return next(self._list_stream)
+
+    def __getstate__(self):
+        return (
+            self._client,
+            self._list_stream.bucket,
+            self._list_stream.prefix,
+            self._list_stream.delimiter,
+            self._list_stream.max_keys,
+            self._list_stream.continuation_token,
+            self._list_stream.complete,
+        )
+
+    def __setstate__(self, state):
+        self._client = state[0]
+        self._list_stream = ListObjectStream._from_state(*state)
+
+
+def _extract_object_info(list_result: ListObjectResult) -> List[ObjectInfo]:
+    return list_result.object_info

--- a/s3dataset/src/s3dataset/s3iterable_dataset.py
+++ b/s3dataset/src/s3dataset/s3iterable_dataset.py
@@ -14,7 +14,7 @@ s3iterable_dataset.py
 class S3IterableDataset(S3DatasetBase, torch.utils.data.IterableDataset):
     @property
     def dataset_objects(self) -> Iterable[S3Object]:
-        return self._dataset_objects
+        return iter(self._dataset_objects)
 
     def __iter__(self) -> Iterator[Any]:
         return map(self._transform, self._dataset_objects)


### PR DESCRIPTION
*Description of changes:*

Add `S3BucketIterable` which can be used to iterate over a bucket multiple times.

`S3BucketIterable` is internal, supports pickle, and resumption partway through iteration.
`S3DatasetBase.from_bucket` now creates a dataset with an S3BucketIterable` instead of a generator of objects.

*Testing:*

Add unit tests that cover iteration of iterable datasets, and pickle/unpickle support.