### PR TITLE
Add S3Client wrapper

### DIFF
--- a/s3dataset/pyproject.toml
+++ b/s3dataset/pyproject.toml
@@ -15,7 +15,10 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest"
+    "pytest",
+    "hypothesis",
+    "flake8",
+    "black"
 ]
 
 e2e = [

--- a/s3dataset/src/s3dataset/_s3_bucket_iterable.py
+++ b/s3dataset/src/s3dataset/_s3_bucket_iterable.py
@@ -3,17 +3,17 @@ from itertools import chain
 from typing import Iterator, List
 
 from s3dataset_s3_client._s3dataset import (
-    MountpointS3Client,
     ObjectInfo,
     ListObjectResult,
     ListObjectStream,
 )
 
+from s3dataset._s3client import S3Client
 from s3dataset_s3_client import S3Object
 
 
 class S3BucketIterable:
-    def __init__(self, client: MountpointS3Client, bucket: str, prefix: str):
+    def __init__(self, client: S3Client, bucket: str, prefix: str):
         self._client = client
         self._bucket = bucket
         self._prefix = prefix
@@ -24,7 +24,7 @@ class S3BucketIterable:
 
 
 class S3BucketIterator:
-    def __init__(self, client: MountpointS3Client, bucket: str, prefix: str):
+    def __init__(self, client: S3Client, bucket: str, prefix: str):
         self._client = client
         self._bucket = bucket
         self._list_stream = _PickleableListObjectStream(client, bucket, prefix)
@@ -45,7 +45,7 @@ class S3BucketIterator:
 
 
 class _PickleableListObjectStream:
-    def __init__(self, client: MountpointS3Client, bucket: str, prefix: str):
+    def __init__(self, client: S3Client, bucket: str, prefix: str):
         self._client = client
         self._list_stream = iter(client.list_objects(bucket, prefix))
 

--- a/s3dataset/src/s3dataset/_s3client/__init__.py
+++ b/s3dataset/src/s3dataset/_s3client/__init__.py
@@ -1,0 +1,4 @@
+from ._s3client import S3Client
+from ._mock_s3client import MockS3Client
+
+__all__ = ["S3Client", "MockS3Client"]

--- a/s3dataset/src/s3dataset/_s3client/_mock_s3client.py
+++ b/s3dataset/src/s3dataset/_s3client/_mock_s3client.py
@@ -1,0 +1,14 @@
+from . import S3Client
+from s3dataset_s3_client._s3dataset import MockMountpointS3Client
+
+
+class MockS3Client(S3Client):
+    def __init__(self, region: str, bucket: str, part_size: int = 8 * 1024 * 1024):
+        self._mock_client = MockMountpointS3Client(region, bucket, part_size=part_size)
+        self._client = self._mock_client.create_mocked_client()
+
+    def add_object(self, key: str, data: bytes) -> None:
+        self._mock_client.add_object(key, data)
+
+    def remove_object(self, key: str) -> None:
+        self._mock_client.remove_object(key)

--- a/s3dataset/src/s3dataset/_s3client/_s3client.py
+++ b/s3dataset/src/s3dataset/_s3client/_s3client.py
@@ -1,0 +1,44 @@
+from functools import partial
+from typing import Optional
+
+from s3dataset_s3_client._s3dataset import (
+    MountpointS3Client,
+    ObjectInfo,
+    ListObjectStream,
+)
+
+from s3dataset_s3_client import S3Object
+from s3dataset_s3_client.put_object_stream_wrapper import PutObjectStreamWrapper
+
+
+class S3Client:
+    def __init__(self, region: str):
+        self._client = MountpointS3Client(region)
+
+    @property
+    def region(self):
+        return self._client.region
+
+    # TODO: S3Object to become S3Reader
+    def get_object(self, bucket: str, key: str) -> S3Object:
+        return S3Object(
+            bucket, key, get_stream=partial(self._client.get_object, bucket, key)
+        )
+
+    # TODO: PutObjectStreamWrapper -> S3Writer
+    def put_object(
+        self, bucket: str, key: str, storage_class: Optional[str] = None
+    ) -> PutObjectStreamWrapper:
+        return PutObjectStreamWrapper(
+            self._client.put_object(bucket, key, storage_class)
+        )
+
+    # TODO: Probably need a ListObjectResult on dataset side
+    def list_objects(
+        self, bucket: str, prefix: str = "", delimiter: str = "", max_keys: int = 1000
+    ) -> ListObjectStream:
+        return self._client.list_objects(bucket, prefix, delimiter, max_keys)
+
+    # TODO: We need ObjectInfo on dataset side
+    def head_object(self, bucket: str, key: str) -> ObjectInfo:
+        return self._client.head_object(bucket, key)

--- a/s3dataset/tst/unit/test_s3dataset_base.py
+++ b/s3dataset/tst/unit/test_s3dataset_base.py
@@ -3,7 +3,8 @@ from typing import Iterable, Union, Sequence
 
 import pytest
 
-from s3dataset_s3_client._s3dataset import S3DatasetException, MockMountpointS3Client
+from s3dataset_s3_client._s3dataset import S3DatasetException
+from s3dataset._s3client import MockS3Client
 
 from s3dataset.s3dataset_base import (
     _parse_s3_uri,
@@ -128,8 +129,8 @@ def test_get_objects_from_uris_fail(uri, error_msg):
 def _create_mock_client_with_dummy_objects(
     bucket: str, keys: Union[str, Iterable[str]]
 ):
-    mock_client = MockMountpointS3Client(TEST_REGION, bucket)
+    mock_client = MockS3Client(TEST_REGION, bucket)
     for key in keys:
         content = f"{bucket}-{key}-dummyData".encode()
         mock_client.add_object(key, content)
-    return mock_client.create_mocked_client()
+    return mock_client


### PR DESCRIPTION
*Description of changes:*

To decouple the actual client used, we add S3Client, a wrapper on top of the current MountpointS3Client and its equivalent mock class. 

--------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
