### PR TITLE
Refactor PutObjectStreamWrapper to S3Writer

### DIFF
--- a/s3dataset/src/s3dataset/__init__.py
+++ b/s3dataset/src/s3dataset/__init__.py
@@ -1,5 +1,6 @@
+from ._s3client import S3Reader, S3Writer
 from .s3dataset_base import S3DatasetBase
 from .s3iterable_dataset import S3IterableDataset
 from .s3map_dataset import S3MapDataset
 
-__all__ = ["S3IterableDataset", "S3MapDataset"]
+__all__ = ["S3IterableDataset", "S3MapDataset", "S3Reader", "S3Writer"]

--- a/s3dataset/src/s3dataset/_s3_bucket_iterable.py
+++ b/s3dataset/src/s3dataset/_s3_bucket_iterable.py
@@ -30,11 +30,11 @@ class S3BucketIterator:
 
     def __iter__(self) -> Iterator[S3Reader]:
         return map(
-            self._create_s3_object,
+            self._create_s3reader,
             chain.from_iterable(map(_extract_object_info, self._list_stream)),
         )
 
-    def _create_s3_object(self, object_info: ObjectInfo):
+    def _create_s3reader(self, object_info: ObjectInfo):
         return S3Reader(
             self._bucket,
             object_info.key,

--- a/s3dataset/src/s3dataset/_s3client/__init__.py
+++ b/s3dataset/src/s3dataset/_s3client/__init__.py
@@ -1,6 +1,6 @@
 from ._s3client import S3Client
 from ._mock_s3client import MockS3Client
 from .s3reader import S3Reader
-from .put_object_stream_wrapper import PutObjectStreamWrapper
+from .s3writer import S3Writer
 
 __all__ = ["S3Client", "MockS3Client"]

--- a/s3dataset/src/s3dataset/_s3client/_mock_s3client.py
+++ b/s3dataset/src/s3dataset/_s3client/_mock_s3client.py
@@ -2,6 +2,11 @@ from s3dataset_s3_client._s3dataset import MockMountpointS3Client, MountpointS3C
 
 from . import S3Client
 
+"""
+_mock_s3client.py
+    Internal client wrapper mock class for unit testing.
+"""
+
 
 class MockS3Client(S3Client):
     def __init__(self, region: str, bucket: str, part_size: int = 8 * 1024 * 1024):

--- a/s3dataset/src/s3dataset/_s3client/s3reader.py
+++ b/s3dataset/src/s3dataset/_s3client/s3reader.py
@@ -5,8 +5,8 @@ from typing import Callable, Optional
 from s3dataset_s3_client._s3dataset import ObjectInfo, GetObjectStream
 
 """
-s3_object.py
-    File like representation of an S3 object.
+s3reader.py
+    File like representation of a readable S3 object.
 """
 
 
@@ -142,5 +142,8 @@ class S3Reader(io.BufferedIOBase):
     def tell(self) -> int:
         return self._position
 
-    def writable(self):
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
         return False

--- a/s3dataset/src/s3dataset/_s3client/s3writer.py
+++ b/s3dataset/src/s3dataset/_s3client/s3writer.py
@@ -1,9 +1,15 @@
+import io
 from typing import Union
 
 from s3dataset_s3_client._s3dataset import PutObjectStream
 
+"""
+s3writer.py
+    File like representation of a writeable S3 object.
+"""
 
-class PutObjectStreamWrapper:
+
+class S3Writer(io.BufferedIOBase):
     def __init__(self, stream: PutObjectStream):
         self.stream = stream
 
@@ -24,3 +30,9 @@ class PutObjectStreamWrapper:
 
     def flush(self):
         pass
+
+    def readable(self) -> bool:
+        return False
+
+    def writable(self) -> bool:
+        return True

--- a/s3dataset/tst/e2e/test_e2e_s3datasets.py
+++ b/s3dataset/tst/e2e/test_e2e_s3datasets.py
@@ -59,7 +59,7 @@ def test_dataloader_10_images_s3iterable_dataset(
     "batch_size, expected_batch_count",
     [(1, 10), (2, 5), (4, 3), (10, 1)],
 )
-def test_dataloader_10_images_s3mapstyle_dataset(
+def test_dataloader_10_images_s3mapdataset(
     batch_size: int, expected_batch_count: int, image_directory
 ):
     local_dataloader = _create_local_dataloader(image_directory, batch_size, True)

--- a/s3dataset/tst/e2e/test_multiprocess_dataloading.py
+++ b/s3dataset/tst/e2e/test_multiprocess_dataloading.py
@@ -116,6 +116,7 @@ def test_s3iterable_dataset_multiprocess(
         assert dict(s3keys) == {key: num_workers for key in image_directory}
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("start_method, dataset_builder", test_args)
 def test_s3mapdataset_multiprocess(
     start_method: str,
@@ -153,9 +154,9 @@ def _set_start_method(start_method: str):
     torch.multiprocessing.set_start_method(start_method, force=True)
 
 
-def _extract_object_data(s3_object: S3Reader) -> ((str, bytes), (int, int)):
-    assert s3_object._stream is None
-    return _read_data(s3_object), _get_worker_info()
+def _extract_object_data(s3reader: S3Reader) -> ((str, bytes), (int, int)):
+    assert s3reader._stream is None
+    return _read_data(s3reader), _get_worker_info()
 
 
 def _get_worker_info() -> (int, int):
@@ -164,5 +165,5 @@ def _get_worker_info() -> (int, int):
     return worker_info.id, worker_info.num_workers
 
 
-def _read_data(s3_object: S3Reader) -> Tuple[str, bytes]:
-    return s3_object.key, s3_object.read()
+def _read_data(s3reader: S3Reader) -> Tuple[str, bytes]:
+    return s3reader.key, s3reader.read()


### PR DESCRIPTION
*Description*
Add readable(), writable() methods, documentation and leftover renamings from S3Reader refactoring.
Mark multiloading MapDataset test as @pytest.mark.xfail due to segfault issue on ubuntu-22.04.