### PR TITLE
Implement `S3Checkpoint`

### DIFF
--- a/s3dataset/src/s3dataset/__init__.py
+++ b/s3dataset/src/s3dataset/__init__.py
@@ -1,6 +1,7 @@
+from .s3checkpoint import S3Checkpoint
 from ._s3client import S3Reader, S3Writer
 from .s3dataset_base import S3DatasetBase
 from .s3iterable_dataset import S3IterableDataset
 from .s3map_dataset import S3MapDataset
 
-__all__ = ["S3IterableDataset", "S3MapDataset", "S3Reader", "S3Writer"]
+__all__ = ["S3IterableDataset", "S3MapDataset", "S3Reader", "S3Writer", "S3Checkpoint"]

--- a/s3dataset/src/s3dataset/_s3_bucket_iterable.py
+++ b/s3dataset/src/s3dataset/_s3_bucket_iterable.py
@@ -30,16 +30,8 @@ class S3BucketIterator:
 
     def __iter__(self) -> Iterator[S3Reader]:
         return map(
-            self._create_s3reader,
+            partial(self._client.from_bucket_and_object_info, self._bucket),
             chain.from_iterable(map(_extract_object_info, self._list_stream)),
-        )
-
-    def _create_s3reader(self, object_info: ObjectInfo):
-        return S3Reader(
-            self._bucket,
-            object_info.key,
-            object_info,
-            get_stream=partial(self._client.get_object, self._bucket, object_info.key),
         )
 
 

--- a/s3dataset/src/s3dataset/_s3client/__init__.py
+++ b/s3dataset/src/s3dataset/_s3client/__init__.py
@@ -3,4 +3,4 @@ from ._mock_s3client import MockS3Client
 from .s3reader import S3Reader
 from .s3writer import S3Writer
 
-__all__ = ["S3Client", "MockS3Client"]
+__all__ = ["S3Client", "MockS3Client", "S3Reader", "S3Writer"]

--- a/s3dataset/src/s3dataset/_s3client/s3reader.py
+++ b/s3dataset/src/s3dataset/_s3client/s3reader.py
@@ -15,23 +15,27 @@ class S3Reader(io.BufferedIOBase):
         self,
         bucket: str,
         key: str,
-        object_info: ObjectInfo = None,
+        get_object_info: Callable[[], ObjectInfo] = None,
         get_stream: Callable[[], GetObjectStream] = None,
     ):
         if not bucket:
             raise ValueError("Bucket should be specified")
         self.bucket = bucket
         self.key = key
-        self.object_info = object_info
+        self._get_object_info = get_object_info
+        self._object_info = None
         self._get_stream = get_stream
         self._stream = None
         self._buffer = io.BytesIO()
-        if object_info is not None:
-            self._size = object_info.size
-        else:
-            self._size = None
+        self._size = None
         # Invariant: _position == _buffer._tell() unless _position_at_end()
         self._position = 0
+
+    @property
+    def object_info(self):
+        if self._object_info is None:
+            self._object_info = self._get_object_info()
+        return self._object_info
 
     def prefetch(self) -> None:
         """
@@ -121,7 +125,7 @@ class S3Reader(io.BufferedIOBase):
 
     def _get_size(self) -> int:
         if self._size is None:
-            raise NotImplementedError("TODO - implement HeadObject")
+            self._size = self.object_info.size
         return self._size
 
     def _position_at_end(self) -> bool:

--- a/s3dataset/src/s3dataset/s3checkpoint.py
+++ b/s3dataset/src/s3dataset/s3checkpoint.py
@@ -1,0 +1,16 @@
+from s3dataset.s3dataset_base import _parse_s3_uri
+from s3dataset._s3client import S3Client, S3Reader, S3Writer
+
+
+class S3Checkpoint:
+    def __init__(self, region: str):
+        self.region = region
+        self._client = S3Client(region)
+
+    def reader(self, s3_uri: str) -> S3Reader:
+        bucket, key = _parse_s3_uri(s3_uri)
+        return self._client.get_object(bucket, key)
+
+    def writer(self, s3_uri: str) -> S3Writer:
+        bucket, key = _parse_s3_uri(s3_uri)
+        return self._client.put_object(bucket, key)

--- a/s3dataset/src/s3dataset/s3dataset_base.py
+++ b/s3dataset/src/s3dataset/s3dataset_base.py
@@ -121,7 +121,7 @@ def _bucket_key_pairs_to_objects(
     bucket_key_pairs: List[Tuple[str, str]], client: S3Client
 ):
     for bucket, key in bucket_key_pairs:
-        yield S3Reader(bucket, key, get_stream=partial(client.get_object, bucket, key))
+        yield client.get_object(bucket, key)
 
 
 def _list_objects_from_prefix(s3_uri: str, client: S3Client) -> S3BucketIterable:

--- a/s3dataset/tst/e2e/conftest.py
+++ b/s3dataset/tst/e2e/conftest.py
@@ -1,8 +1,6 @@
-from dataclasses import dataclass
 import io
 import os
 import random
-from typing import Dict
 
 import boto3
 import numpy as np
@@ -32,6 +30,10 @@ class BucketPrefixFixture(object):
         self.contents = {}
         session = boto3.Session(region_name=region)
         self.s3 = session.client("s3")
+
+    @property
+    def s3_uri(self):
+        return f"s3://{self.bucket}/{self.prefix}"
 
     def add(self, key: str, contents: bytes, **kwargs):
         """Upload an S3 object to this prefix of the bucket."""
@@ -78,3 +80,8 @@ def image_directory(request) -> BucketPrefixFixture:
         fixture.add(key, image_bytes)
 
     return fixture
+
+
+@pytest.fixture
+def checkpoint_directory(request) -> BucketPrefixFixture:
+    return get_test_bucket_prefix(f"{request.node.name}/checkpoint_directory")

--- a/s3dataset/tst/e2e/test_e2e_s3checkpoint.py
+++ b/s3dataset/tst/e2e/test_e2e_s3checkpoint.py
@@ -1,0 +1,84 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from s3dataset import S3Checkpoint
+
+
+def test_general_checkpointing(checkpoint_directory):
+    tensor = torch.tensor([[0.1, 1.2], [2.2, 3.1], [4.9, 5.2]])
+    checkpoint_name = "general_checkpoint.pt"
+    checkpoint = S3Checkpoint(region=checkpoint_directory.region)
+    s3_uri = f"{checkpoint_directory.s3_uri}/{checkpoint_name}"
+    with checkpoint.writer(s3_uri) as writer:
+        torch.save(tensor, writer)
+
+    loaded = torch.load(checkpoint.reader(s3_uri))
+
+    assert torch.equal(tensor, loaded)
+
+
+def test_nn_checkpointing(checkpoint_directory):
+    nn_model = Net()
+    checkpoint_name = "neural_network_model.pt"
+    checkpoint = S3Checkpoint(region=checkpoint_directory.region)
+
+    epoch = 5
+    s3_uri = f"{checkpoint_directory.s3_uri}/{checkpoint_name}"
+    loss = 0.4
+
+    with checkpoint.writer(s3_uri) as writer:
+        torch.save(
+            {
+                "epoch": epoch,
+                "model_state_dict": nn_model.state_dict(),
+                "loss": loss,
+            },
+            writer,
+        )
+
+    loaded_nn_model = Net()
+
+    # assert models are not equal before loading from checkpoint
+    assert not nn_model.equals(loaded_nn_model)
+
+    loaded_checkpoint = torch.load(checkpoint.reader(s3_uri))
+    loaded_nn_model.load_state_dict(loaded_checkpoint["model_state_dict"])
+    assert nn_model.equals(loaded_nn_model)
+
+    loaded_epoch = loaded_checkpoint["epoch"]
+    loaded_loss = loaded_checkpoint["loss"]
+    assert loss == loaded_loss
+    assert epoch == loaded_epoch
+
+    # Assert that eval and train do not raise
+    loaded_nn_model.eval()
+    loaded_nn_model.train()
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+    def equals(self, other_model: nn.Module) -> bool:
+        for key_item_1, key_item_2 in zip(
+            self.state_dict().items(), other_model.state_dict().items()
+        ):
+            if not torch.equal(key_item_1[1], key_item_2[1]):
+                return False
+        return True

--- a/s3dataset/tst/unit/test_s3dataset_base.py
+++ b/s3dataset/tst/unit/test_s3dataset_base.py
@@ -105,7 +105,7 @@ def test_get_objects_from_uris_success(
         assert object is not None
         assert object.bucket == TEST_BUCKET
         assert object.key == expected_keys[index]
-        assert object.object_info is None
+        assert object._get_object_info is not None
         assert object._get_stream is not None
     assert count == len(expected_keys)
 

--- a/s3dataset/tst/unit/test_s3iterable_dataset.py
+++ b/s3dataset/tst/unit/test_s3iterable_dataset.py
@@ -46,7 +46,9 @@ def test_dataset_creation_from_objects(
     dataset._client = client
 
     assert isinstance(dataset, S3IterableDataset)
-    _verify_dataset(dataset, expected_keys, lambda data: data.object_info is None)
+    _verify_dataset(
+        dataset, expected_keys, lambda data: data._get_object_info is not None
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add Checkpointing save/load Support to s3torchconnector

This introduces checkpoint api and initial end to end testing for general checkpointing.

*Description of changes:*
- We are adding HeadObject and converting object_info of S3Reader to get_object_info callable to be able to use torch.load

With this pr, https://github.com/awslabs/s3-connector-for-pytorch/pull/33 is no longer required. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
