### PR TITLE
Temporarily disable s3torchconnector audit check

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -192,10 +192,11 @@ jobs:
         with:
           inputs: "s3torchconnectorclient"
 
-      - name: Audit s3torchconnector dependencies
-        uses: pypa/gh-action-pip-audit@v1.0.0
-        with:
-          inputs: "s3torchconnector"
+# TODO: Re-enable after publishing
+#      - name: Audit s3torchconnector dependencies
+#        uses: pypa/gh-action-pip-audit@v1.0.0
+#        with:
+#          inputs: "s3torchconnector"
 
       - name: Security vulnerabilities check s3torchconnector
         run: safety check -r s3torchconnector/requirements.txt


### PR DESCRIPTION
CI fails due to the dummy packages published.
Temporary disable s3torchconnector audit check
to address this. Needs to be re-enabled after
publishing the packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
