### PR TITLE
Update readme to use github.com URLs rather than relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ automatically optimizes performance when downloading training data from and writ
 pip install s3torchconnector
 ```
 
-Amazon S3 Connector for PyTorch supports only Linux via Pip for now. For other platforms, see [DEVELOPMENT](doc/DEVELOPMENT.md) for build instructions.
+Amazon S3 Connector for PyTorch supports only Linux via Pip for now. For other platforms, see [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) for build instructions.
 
 ### Configuration
 
@@ -36,7 +36,7 @@ To use `s3torchconnector`, AWS credentials must be provided through one of the f
 ### Examples
 
 [API docs](http://awslabs.github.io/s3-connector-for-pytorch) are showing API of the public components. 
-End to end example of how to use `s3torchconnector` can be found under the [examples](examples/) directory.
+End to end example of how to use `s3torchconnector` can be found under the [examples](https://github.com/awslabs/s3-connector-for-pytorch/tree/main/examples) directory.
 
 #### Sample Examples
 
@@ -93,10 +93,10 @@ model.load_state_dict(state_dict)
 ```
 
 ## Contributing
-We welcome contributions to Amazon S3 Connector for PyTorch. Please see [CONTRIBUTING](doc/CONTRIBUTING.md) For more information on how to report bugs or submit pull requests.
+We welcome contributions to Amazon S3 Connector for PyTorch. Please see [CONTRIBUTING](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/CONTRIBUTING.md) For more information on how to report bugs or submit pull requests.
 
 ### Development
-See [DEVELOPMENT](doc/DEVELOPMENT.md) for information about code style,
+See [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) for information about code style,
 development process, and guidelines.
 
 
@@ -105,9 +105,9 @@ If you discover a potential security issue in this project we ask that you notif
 
 ### Code of conduct
 
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). See [CODE_OF_CONDUCT.md](doc/CODE_OF_CONDUCT.md) for more details.
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). See [CODE_OF_CONDUCT.md](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/CODE_OF_CONDUCT.md) for more details.
 
 ## License
 
-Amazon S3 Connector for PyTorch has a BSD 3-Clause License, as found in the [LICENSE](LICENSE) file.
+Amazon S3 Connector for PyTorch has a BSD 3-Clause License, as found in the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE) file.
 


### PR DESCRIPTION
## Description

Update readme to use github.com URLs rather than relative URLs


## Additional context

On sites like PyPI we want to link people to github rather than keep them on-site.

## Testing

This was the Readme we pushed to PyPI

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
