### PR TITLE
Use correct names for unit/integration test workflows

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -57,9 +57,9 @@ jobs:
           python -m pip install -e "s3torchconnectorclient[test]"
           python -m pip install -e "s3torchconnector[test]"
 
-      - name: Client unit tests
+      - name: s3torchconnectorclient unit tests
         run: pytest s3torchconnectorclient/python/tst/unit --hypothesis-profile ci --hypothesis-show-statistics
-      - name: Dataset unit tests
+      - name: s3torchconnector unit tests
         run: pytest s3torchconnector/tst/unit --hypothesis-profile ci --hypothesis-show-statistics
 
   lint:

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -77,7 +77,7 @@ jobs:
           python -m pip install -e "s3torchconnectorclient[test,e2e]"
           python -m pip install -e "s3torchconnector[test,e2e]"
 
-      - name: Dataset integration tests
+      - name: s3torchconnector integration tests
         run: pytest s3torchconnector/tst/e2e -n auto
 
       - name: Save Cargo cache


### PR DESCRIPTION
## Description

Workflows used old names for titles. Use the new package names instead.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
