### PR TITLE
Align imports and fix API docs

### DIFF
--- a/s3torchconnector/src/s3torchconnector/__init__.py
+++ b/s3torchconnector/src/s3torchconnector/__init__.py
@@ -2,10 +2,13 @@
 #  // SPDX-License-Identifier: BSD
 from s3torchconnectorclient import S3Exception
 
-from .s3checkpoint import S3Checkpoint
-from ._s3client import S3Reader, S3Writer
+# The order of these imports is the same in which they will be rendered
+# in the API docs generated with Sphinx.
 from .s3iterable_dataset import S3IterableDataset
 from .s3map_dataset import S3MapDataset
+from .s3checkpoint import S3Checkpoint
+from ._s3client.s3reader import S3Reader
+from ._s3client.s3writer import S3Writer
 
 __all__ = [
     "S3IterableDataset",

--- a/s3torchconnector/src/s3torchconnector/_s3_bucket_iterable.py
+++ b/s3torchconnector/src/s3torchconnector/_s3_bucket_iterable.py
@@ -11,7 +11,8 @@ from s3torchconnectorclient._mountpoint_s3_client import (
     ListObjectStream,
 )
 
-from s3torchconnector._s3client import S3Client, S3Reader
+from ._s3client import S3Client
+from ._s3client import S3Reader
 
 
 class S3BucketIterable:

--- a/s3torchconnector/src/s3torchconnector/_s3client/__init__.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/__init__.py
@@ -2,8 +2,8 @@
 #  // SPDX-License-Identifier: BSD
 
 from ._s3client import S3Client
-from ._mock_s3client import MockS3Client
 from .s3reader import S3Reader
 from .s3writer import S3Writer
+from ._mock_s3client import MockS3Client
 
 __all__ = ["S3Client", "MockS3Client", "S3Reader", "S3Writer"]

--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -7,7 +7,6 @@ from typing import Optional, Any
 
 from .s3reader import S3Reader
 from .s3writer import S3Writer
-
 from s3torchconnector._version import user_agent_prefix
 
 from s3torchconnectorclient._mountpoint_s3_client import (

--- a/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
+++ b/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
@@ -8,8 +8,9 @@ from typing import (
     List,
 )
 
-from s3torchconnector._s3_bucket_iterable import S3BucketIterable
-from s3torchconnector._s3client import S3Client, S3Reader
+from ._s3_bucket_iterable import S3BucketIterable
+from ._s3client import S3Client
+from ._s3client.s3reader import S3Reader
 
 """
 _s3dataset_common.py

--- a/s3torchconnector/src/s3torchconnector/s3checkpoint.py
+++ b/s3torchconnector/src/s3torchconnector/s3checkpoint.py
@@ -1,8 +1,10 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 
-from s3torchconnector._s3dataset_common import parse_s3_uri
-from s3torchconnector._s3client import S3Client, S3Reader, S3Writer
+from ._s3dataset_common import parse_s3_uri
+from ._s3client import S3Client
+from ._s3client.s3reader import S3Reader
+from ._s3client.s3writer import S3Writer
 
 
 class S3Checkpoint:

--- a/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
@@ -5,7 +5,7 @@ from typing import Iterator, Any, Union, Iterable, Callable
 
 import torch.utils.data
 
-from . import S3Reader
+from ._s3client.s3reader import S3Reader
 from ._s3client import S3Client
 from ._s3dataset_common import (
     identity,

--- a/s3torchconnector/src/s3torchconnector/s3map_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3map_dataset.py
@@ -5,7 +5,8 @@ from typing import List, Any, Callable, Iterable, Union
 
 import torch.utils.data
 
-from ._s3client import S3Client, S3Reader
+from ._s3client import S3Client
+from ._s3client.s3reader import S3Reader
 
 from ._s3dataset_common import (
     get_objects_from_uris,

--- a/s3torchconnector/tst/e2e/test_multiprocess_dataloading.py
+++ b/s3torchconnector/tst/e2e/test_multiprocess_dataloading.py
@@ -13,8 +13,7 @@ import torch
 from torch.utils.data import DataLoader, get_worker_info
 from torchdata.datapipes.iter import IterableWrapper
 
-from s3torchconnector import S3IterableDataset, S3MapDataset
-from s3torchconnector._s3client import S3Reader
+from s3torchconnector import S3IterableDataset, S3MapDataset, S3Reader
 
 if TYPE_CHECKING:
     from .conftest import BucketPrefixFixture

--- a/s3torchconnector/tst/unit/test_checkpointing.py
+++ b/s3torchconnector/tst/unit/test_checkpointing.py
@@ -32,7 +32,7 @@ from hypothesis.strategies import (
 )
 
 from s3torchconnector._s3client import MockS3Client
-from s3torchconnector.s3checkpoint import S3Checkpoint
+from s3torchconnector import S3Checkpoint
 
 TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key"

--- a/s3torchconnector/tst/unit/test_s3iterable_dataset.py
+++ b/s3torchconnector/tst/unit/test_s3iterable_dataset.py
@@ -5,8 +5,7 @@ from typing import Iterable, Callable, Sequence, Any
 
 import pytest
 
-from s3torchconnector import S3IterableDataset
-from s3torchconnector._s3client import S3Reader
+from s3torchconnector import S3IterableDataset, S3Reader
 
 from test_s3dataset_common import (
     TEST_BUCKET,

--- a/s3torchconnector/tst/unit/test_s3mapdataset.py
+++ b/s3torchconnector/tst/unit/test_s3mapdataset.py
@@ -5,8 +5,7 @@ from typing import Sequence, Callable, Any
 
 import pytest
 
-from s3torchconnector import S3MapDataset
-from s3torchconnector._s3client import S3Reader
+from s3torchconnector import S3MapDataset, S3Reader
 
 from test_s3dataset_common import (
     TEST_BUCKET,

--- a/s3torchconnector/tst/unit/test_s3reader.py
+++ b/s3torchconnector/tst/unit/test_s3reader.py
@@ -12,7 +12,7 @@ from hypothesis import given, assume
 from hypothesis.strategies import lists, binary, integers, composite
 from s3torchconnectorclient._mountpoint_s3_client import ObjectInfo, GetObjectStream
 
-from s3torchconnector._s3client import S3Reader
+from s3torchconnector import S3Reader
 
 logging.basicConfig(
     format="%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"


### PR DESCRIPTION
Imports for S3Reader and S3Writer are not consistent.
Update their imports. Align the order they show up on API reference page.

## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
Enhancements for our API docs: https://awslabs.github.io/s3-connector-for-pytorch/

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->
* No breaking change. 

## Testing
<!-- Please describe how these changes were tested. -->

`sphinx-build -b html . _build/html`

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
