### PR TITLE
Avoid excessive memory consumption when utilizing s3map_dataset 

### DIFF
--- a/s3torchconnector/src/s3torchconnector/_s3bucket_key.py
+++ b/s3torchconnector/src/s3torchconnector/_s3bucket_key.py
@@ -1,23 +1,10 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
+from typing import NamedTuple
 
-class S3BucketKey(object):
+
+class S3BucketKey(NamedTuple):
     """Read-only information about object stored in S3."""
 
-    def __init__(
-            self,
-            bucket: str,
-            key: str,
-    ):
-        if not bucket:
-            raise ValueError("Bucket should be specified")
-        self._bucket = bucket
-        self._key = key
-
-    @property
-    def bucket(self):
-        return self._bucket
-
-    @property
-    def key(self):
-        return self._key
+    bucket: str
+    key: str

--- a/s3torchconnector/src/s3torchconnector/_s3bucket_key.py
+++ b/s3torchconnector/src/s3torchconnector/_s3bucket_key.py
@@ -1,0 +1,23 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+class S3BucketKey(object):
+    """Read-only information about object stored in S3."""
+
+    def __init__(
+            self,
+            bucket: str,
+            key: str,
+    ):
+        if not bucket:
+            raise ValueError("Bucket should be specified")
+        self._bucket = bucket
+        self._key = key
+
+    @property
+    def bucket(self):
+        return self._bucket
+
+    @property
+    def key(self):
+        return self._key

--- a/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
+++ b/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
@@ -1,7 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 
-from typing import Iterable, Union, Tuple, List
+from typing import Iterable, Union, Tuple
 
 from ._s3_bucket_iterable import S3BucketIterable
 from ._s3client import S3Client
@@ -44,15 +44,10 @@ def get_objects_from_uris(
     # TODO: We should be consistent with URIs parsing. Revise if we want to do this upfront or lazily.
     bucket_key_pairs = [parse_s3_uri(uri) for uri in object_uris]
 
-    return bucket_key_pairs_to_objects(bucket_key_pairs)
+    return (S3BucketKey(bucket, key) for bucket, key in bucket_key_pairs)
 
 
-def bucket_key_pairs_to_objects(bucket_key_pairs: List[Tuple[str, str]]):
-    for bucket, key in bucket_key_pairs:
-        yield S3BucketKey(bucket, key)
-
-
-def list_objects_from_prefix(s3_uri: str, client: S3Client) -> Iterable[S3BucketKey]:
+def get_objects_from_prefix(s3_uri: str, client: S3Client) -> Iterable[S3BucketKey]:
     bucket, prefix = parse_s3_uri(s3_uri)
     s3objects = S3BucketIterable(client, bucket, prefix)
     bucket_key_pairs = (S3BucketKey(obj.bucket, obj.key) for obj in s3objects)

--- a/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
+++ b/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
@@ -41,8 +41,7 @@ def get_objects_from_uris(
 ) -> Iterable[S3BucketKey]:
     if isinstance(object_uris, str):
         object_uris = [object_uris]
-    # TODO: We should be consistent with URIs parsing. Revise if we want to do this upfront or lazily.
-    bucket_key_pairs = [S3BucketKey(*parse_s3_uri(uri)) for uri in object_uris]
+    bucket_key_pairs = (S3BucketKey(*parse_s3_uri(uri)) for uri in object_uris)
 
     return bucket_key_pairs
 

--- a/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
+++ b/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
@@ -1,7 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 
-from typing import Iterable, Union, Tuple
+from typing import Iterable, Union, Tuple, List
 
 from ._s3_bucket_iterable import S3BucketIterable
 from ._s3client import S3Client
@@ -41,9 +41,15 @@ def get_objects_from_uris(
 ) -> Iterable[S3BucketKey]:
     if isinstance(object_uris, str):
         object_uris = [object_uris]
-    bucket_key_pairs = (S3BucketKey(*parse_s3_uri(uri)) for uri in object_uris)
+    # TODO: We should be consistent with URIs parsing. Revise if we want to do this upfront or lazily.
+    bucket_key_pairs = [parse_s3_uri(uri) for uri in object_uris]
 
-    return bucket_key_pairs
+    return bucket_key_pairs_to_objects(bucket_key_pairs)
+
+
+def bucket_key_pairs_to_objects(bucket_key_pairs: List[Tuple[str, str]]):
+    for bucket, key in bucket_key_pairs:
+        yield S3BucketKey(bucket, key)
 
 
 def list_objects_from_prefix(s3_uri: str, client: S3Client) -> Iterable[S3BucketKey]:

--- a/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
+++ b/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
@@ -1,16 +1,12 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 
-from typing import (
-    Iterable,
-    Union,
-    Tuple,
-    List,
-)
+from typing import Iterable, Union, Tuple
 
 from ._s3_bucket_iterable import S3BucketIterable
 from ._s3client import S3Client
 from . import S3Reader
+from ._s3bucket_key import S3BucketKey
 
 """
 _s3dataset_common.py
@@ -42,22 +38,18 @@ def parse_s3_uri(uri: str) -> Tuple[str, str]:
 
 def get_objects_from_uris(
     object_uris: Union[str, Iterable[str]], client: S3Client
-) -> Iterable[S3Reader]:
+) -> Iterable[S3BucketKey]:
     if isinstance(object_uris, str):
         object_uris = [object_uris]
     # TODO: We should be consistent with URIs parsing. Revise if we want to do this upfront or lazily.
-    bucket_key_pairs = [parse_s3_uri(uri) for uri in object_uris]
+    bucket_key_pairs = [S3BucketKey(*parse_s3_uri(uri)) for uri in object_uris]
 
-    return bucket_key_pairs_to_objects(bucket_key_pairs, client)
-
-
-def bucket_key_pairs_to_objects(
-    bucket_key_pairs: List[Tuple[str, str]], client: S3Client
-):
-    for bucket, key in bucket_key_pairs:
-        yield client.get_object(bucket, key)
+    return bucket_key_pairs
 
 
-def list_objects_from_prefix(s3_uri: str, client: S3Client) -> S3BucketIterable:
+def list_objects_from_prefix(s3_uri: str, client: S3Client) -> Iterable[S3BucketKey]:
     bucket, prefix = parse_s3_uri(s3_uri)
-    return S3BucketIterable(client, bucket, prefix)
+    s3objects = list(S3BucketIterable(client, bucket, prefix))
+    bucket_key_pairs = [S3BucketKey(obj.bucket, obj.key) for obj in s3objects]
+
+    return bucket_key_pairs

--- a/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
+++ b/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
@@ -49,7 +49,7 @@ def get_objects_from_uris(
 
 def list_objects_from_prefix(s3_uri: str, client: S3Client) -> Iterable[S3BucketKey]:
     bucket, prefix = parse_s3_uri(s3_uri)
-    s3objects = list(S3BucketIterable(client, bucket, prefix))
-    bucket_key_pairs = [S3BucketKey(obj.bucket, obj.key) for obj in s3objects]
+    s3objects = S3BucketIterable(client, bucket, prefix)
+    bucket_key_pairs = (S3BucketKey(obj.bucket, obj.key) for obj in s3objects)
 
     return bucket_key_pairs

--- a/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
@@ -25,7 +25,7 @@ class S3IterableDataset(torch.utils.data.IterableDataset):
     def __init__(
         self,
         region: str,
-        get_dataset_objects: Callable[[S3Client], Iterable[S3Reader]],
+        get_dataset_objects: Callable[[S3Client], Iterable[S3BucketKey]],
         transform: Callable[[S3Reader], Any] = identity,
     ):
         self._get_dataset_objects = get_dataset_objects
@@ -92,7 +92,7 @@ class S3IterableDataset(torch.utils.data.IterableDataset):
             self._client = S3Client(self.region)
         return self._client
 
-    def _get_transformed_object(self, bucket_key: S3BucketKey) -> S3Reader:
+    def _get_transformed_object(self, bucket_key: S3BucketKey) -> Any:
         return self._transform(
             self._get_client().get_object(bucket_key.bucket, bucket_key.key)
         )

--- a/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
@@ -11,7 +11,7 @@ from ._s3client import S3Client
 from ._s3dataset_common import (
     identity,
     get_objects_from_uris,
-    list_objects_from_prefix,
+    get_objects_from_prefix,
 )
 
 
@@ -84,7 +84,7 @@ class S3IterableDataset(torch.utils.data.IterableDataset):
             S3Exception: An error occurred accessing S3.
         """
         return cls(
-            region, partial(list_objects_from_prefix, s3_uri), transform=transform
+            region, partial(get_objects_from_prefix, s3_uri), transform=transform
         )
 
     def _get_client(self):

--- a/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
@@ -6,6 +6,7 @@ from typing import Iterator, Any, Union, Iterable, Callable
 import torch.utils.data
 
 from . import S3Reader
+from ._s3bucket_key import S3BucketKey
 from ._s3client import S3Client
 from ._s3dataset_common import (
     identity,
@@ -91,8 +92,12 @@ class S3IterableDataset(torch.utils.data.IterableDataset):
             self._client = S3Client(self.region)
         return self._client
 
-    def _get_transformed_object(self, bucket_key) -> S3Reader:
-        return self._transform(self._get_client().get_object(bucket_key.bucket, bucket_key.key))
+    def _get_transformed_object(self, bucket_key: S3BucketKey) -> S3Reader:
+        return self._transform(
+            self._get_client().get_object(bucket_key.bucket, bucket_key.key)
+        )
 
     def __iter__(self) -> Iterator[Any]:
-        return map(self._get_transformed_object, self._get_dataset_objects(self._get_client()))
+        return map(
+            self._get_transformed_object, self._get_dataset_objects(self._get_client())
+        )

--- a/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
@@ -91,5 +91,8 @@ class S3IterableDataset(torch.utils.data.IterableDataset):
             self._client = S3Client(self.region)
         return self._client
 
+    def _get_transformed_object(self, bucket_key) -> S3Reader:
+        return self._transform(self._get_client().get_object(bucket_key.bucket, bucket_key.key))
+
     def __iter__(self) -> Iterator[Any]:
-        return map(self._transform, self._get_dataset_objects(self._get_client()))
+        return map(self._get_transformed_object, self._get_dataset_objects(self._get_client()))

--- a/s3torchconnector/src/s3torchconnector/s3map_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3map_dataset.py
@@ -42,9 +42,7 @@ class S3MapDataset(torch.utils.data.Dataset):
     @property
     def _dataset_bucket_key_pairs(self) -> List[S3BucketKey]:
         if self._bucket_key_pairs is None:
-            self._bucket_key_pairs = list(
-                self._get_dataset_objects(self._get_client())
-            )
+            self._bucket_key_pairs = list(self._get_dataset_objects(self._get_client()))
         return self._bucket_key_pairs
 
     @classmethod

--- a/s3torchconnector/src/s3torchconnector/s3map_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3map_dataset.py
@@ -26,7 +26,7 @@ class S3MapDataset(torch.utils.data.Dataset):
     def __init__(
         self,
         region: str,
-        get_dataset_objects: Callable[[S3Client], Iterable[S3Reader]],
+        get_dataset_objects: Callable[[S3Client], Iterable[S3BucketKey]],
         transform: Callable[[S3Reader], Any] = identity,
     ):
         self._get_dataset_objects = get_dataset_objects
@@ -101,7 +101,7 @@ class S3MapDataset(torch.utils.data.Dataset):
             self._client = S3Client(self.region)
         return self._client
 
-    def _get_object(self, i) -> S3Reader:
+    def _get_object(self, i: int) -> S3Reader:
         bucket_key = self._dataset_bucket_key_pairs[i]
         return self._get_client().get_object(bucket_key.bucket, bucket_key.key)
 

--- a/s3torchconnector/src/s3torchconnector/s3map_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3map_dataset.py
@@ -11,7 +11,7 @@ from . import S3Reader
 
 from ._s3dataset_common import (
     get_objects_from_uris,
-    list_objects_from_prefix,
+    get_objects_from_prefix,
     identity,
 )
 
@@ -93,7 +93,7 @@ class S3MapDataset(torch.utils.data.Dataset):
             S3Exception: An error occurred accessing S3.
         """
         return cls(
-            region, partial(list_objects_from_prefix, s3_uri), transform=transform
+            region, partial(get_objects_from_prefix, s3_uri), transform=transform
         )
 
     def _get_client(self):

--- a/s3torchconnector/tst/unit/test_s3dataset_common.py
+++ b/s3torchconnector/tst/unit/test_s3dataset_common.py
@@ -69,16 +69,13 @@ def test_list_objects_from_prefix(
     prefix: str, keys: Sequence[str], expected_count: int
 ):
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, keys)
-    objects = list_objects_from_prefix(f"{S3_PREFIX}/{prefix}", mock_client)
+    bucket_key_pairs = list_objects_from_prefix(f"{S3_PREFIX}/{prefix}", mock_client)
     count = 0
-    for index, object in enumerate(objects):
+    for index, bucket_key_pair in enumerate(bucket_key_pairs):
         count += 1
-        assert object is not None
-        assert object.bucket == TEST_BUCKET
-        assert object.key == keys[index]
-        assert object._object_info is not None
-        assert object._object_info.key == keys[index]
-        assert object._get_stream is not None
+        assert bucket_key_pair is not None
+        assert bucket_key_pair.bucket == TEST_BUCKET
+        assert bucket_key_pair.key == keys[index]
     assert count == expected_count
 
 
@@ -101,15 +98,13 @@ def test_get_objects_from_uris_success(
     object_uris: Sequence[str], expected_keys: Sequence[str]
 ):
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, expected_keys)
-    objects = get_objects_from_uris(object_uris, mock_client)
+    bucket_key_pairs = get_objects_from_uris(object_uris, mock_client)
     count = 0
-    for index, object in enumerate(objects):
+    for index, bucket_key_pair in enumerate(bucket_key_pairs):
         count += 1
-        assert object is not None
-        assert object.bucket == TEST_BUCKET
-        assert object.key == expected_keys[index]
-        assert object._get_object_info is not None
-        assert object._get_stream is not None
+        assert bucket_key_pair is not None
+        assert bucket_key_pair.bucket == TEST_BUCKET
+        assert bucket_key_pair.key == expected_keys[index]
     assert count == len(expected_keys)
 
 

--- a/s3torchconnector/tst/unit/test_s3dataset_common.py
+++ b/s3torchconnector/tst/unit/test_s3dataset_common.py
@@ -11,7 +11,7 @@ from s3torchconnector._s3client import MockS3Client
 
 from s3torchconnector._s3dataset_common import (
     parse_s3_uri,
-    list_objects_from_prefix,
+    get_objects_from_prefix,
     get_objects_from_uris,
 )
 
@@ -65,11 +65,9 @@ def test_s3dataset_base_parse_s3_uri_fail(uri, error_msg):
         ("obj", ["obj1", "obj2", "obj3", "test", "test2"], 3),
     ],
 )
-def test_list_objects_from_prefix(
-    prefix: str, keys: Sequence[str], expected_count: int
-):
+def test_get_objects_from_prefix(prefix: str, keys: Sequence[str], expected_count: int):
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, keys)
-    bucket_key_pairs = list_objects_from_prefix(f"{S3_PREFIX}/{prefix}", mock_client)
+    bucket_key_pairs = get_objects_from_prefix(f"{S3_PREFIX}/{prefix}", mock_client)
     count = 0
     for index, bucket_key_pair in enumerate(bucket_key_pairs):
         count += 1
@@ -82,7 +80,7 @@ def test_list_objects_from_prefix(
 def test_list_objects_for_bucket_invalid():
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, [])
     with pytest.raises(S3Exception) as error:
-        objects = list_objects_from_prefix(
+        objects = get_objects_from_prefix(
             "s3://DIFFERENT_BUCKET",
             mock_client,
         )


### PR DESCRIPTION
Fix for https://github.com/awslabs/s3-connector-for-pytorch/issues/89

## Description
The goal of the changes was to minimize the retention time for S3 data loaded in memory. This was achieved by delaying the creation of `S3Readers` until right before reading the given object. Immediately after reading finishes, ownership of the `S3Reader` containing the loaded content is transferred to the calling client.

## Testing
Integration and unit test were run.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
