### PR TITLE
Add a 2-minute timeout to tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,8 +10,10 @@ from hypothesis import settings
 settings.register_profile("ci", max_examples=1000, deadline=timedelta(seconds=1))
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
 
+per_test_timeout = int(os.getenv("TEST_TIMEOUT", "120"))
+
 
 def pytest_collection_modifyitems(items):
     for item in items:
         if item.get_closest_marker("timeout") is None:
-            item.add_marker(pytest.mark.timeout(120))
+            item.add_marker(pytest.mark.timeout(per_test_timeout))

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,14 @@
 import os
 from datetime import timedelta
 
+import pytest
 from hypothesis import settings
 
 settings.register_profile("ci", max_examples=1000, deadline=timedelta(seconds=1))
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if item.get_closest_marker("timeout") is None:
+            item.add_marker(pytest.mark.timeout(120))

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
+    "pytest-timeout",
     "hypothesis",
     "flake8",
     "black"

--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = []
 [project.optional-dependencies]
 test = [
     "pytest",
+    "pytest-timeout",
     "hypothesis",
     "flake8",
     "black"


### PR DESCRIPTION
## Description

Previously we were having issues where our tests would take too long. Now they're set to time out after a specified period.

## Testing

Tests pass.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
