### PR TITLE
Add backslash between prefix and checkpoint name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ from s3torchconnector import S3Checkpoint
 import torchvision
 import torch
 
-CHECKPOINT_URI="s3://<BUCKET>/<KEY>"
+CHECKPOINT_URI="s3://<BUCKET>/<KEY>/"
 REGION = "us-east-1"
 checkpoint = S3Checkpoint(region=REGION)
 


### PR DESCRIPTION
## Description
The checkpoint sample was updated to include backslash after the prefix/key to separate it from checkpoint name.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
