### PR TITLE
Be more explicit on how to use tar datasets with DataLoader in our example

### DIFF
--- a/examples/Getting started with the Amazon S3 Connector for PyTorch.ipynb
+++ b/examples/Getting started with the Amazon S3 Connector for PyTorch.ipynb
@@ -643,7 +643,7 @@
     {
      "data": {
       "text/plain": [
-       "'2022.001.0000.00.DISC.01.jpg.image.jpg'"
+       "['2022.001.0000.00.DISC.01.jpg.image.jpg']"
       ]
      },
      "metadata": {},
@@ -663,7 +663,7 @@
     {
      "data": {
       "text/plain": [
-       "'2022.001.0320.00.DISC.01.jpg.image.jpg'"
+       "['2022.001.0320.00.DISC.01.jpg.image.jpg']"
       ]
      },
      "metadata": {},
@@ -683,7 +683,7 @@
     {
      "data": {
       "text/plain": [
-       "'2022.001.0640.00.DISC.01.jpg.image.jpg'"
+       "['2022.001.0640.00.DISC.01.jpg.image.jpg']"
       ]
      },
      "metadata": {},
@@ -745,12 +745,15 @@
     "def shard_to_dict(object):\n",
     "    return {\"url\": object.key, \"stream\": object}\n",
     "\n",
-    "dataset = s3torchconnector.S3IterableDataset.from_prefix(SHARDS_URI, region=REGION, transform=shard_to_dict)\n",
-    "dataset = webdataset.tariterators.tar_file_expander(dataset)\n",
+    "s3_dataset = s3torchconnector.S3IterableDataset.from_prefix(SHARDS_URI, region=REGION, transform=shard_to_dict)\n",
+    "tar_dataset = webdataset.tariterators.tar_file_expander(s3_dataset)\n",
+    "dataset = torchdata.datapipes.iter.IterableWrapper(tar_dataset, deepcopy=False)\n",
     "\n",
-    "for sample in itertools.islice(dataset, 0, 100, 20):\n",
+    "loader = torch.utils.data.DataLoader(dataset)\n",
+    "\n",
+    "for sample in itertools.islice(loader, 0, 100, 20):\n",
     "    display(sample[\"fname\"])\n",
-    "    display(Image.open(io.BytesIO(sample[\"data\"])).reduce(8))"
+    "    display(Image.open(io.BytesIO(sample[\"data\"][0])).reduce(8))"
    ]
   },
   {


### PR DESCRIPTION
## Description

In https://github.com/awslabs/s3-connector-for-pytorch/issues/102, we found it wasn't obvious how to integrate `tar_file_expander` with `DataLoader`, and our example for tar file extraction skipped over it. 
This PR adds an explicit example for showing how to wrap an iterable such as one returned by `tar_file_expander` into a dataloader. 


<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->


No changes to the codebase.

## Related items

https://github.com/awslabs/s3-connector-for-pytorch/issues/102

## Testing

- Executed code for new changes and verified they behaved as expected.
- Viewed modified Jupyter notebook and saw that it was rendered correctly.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
