### PR TITLE
Add public version attributes

### DIFF
--- a/s3torchconnector/docs/conf.py
+++ b/s3torchconnector/docs/conf.py
@@ -11,6 +11,7 @@
 #
 import os
 import sys
+from s3torchconnector import __version__
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -21,7 +22,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "Amazon S3 Connector for PyTorch"
 copyright = "2023, Amazon S3"
 author = "Amazon S3"
-release = "1.1.1"
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/s3torchconnector/src/s3torchconnector/__init__.py
+++ b/s3torchconnector/src/s3torchconnector/__init__.py
@@ -10,6 +10,7 @@ from .s3writer import S3Writer
 from .s3iterable_dataset import S3IterableDataset
 from .s3map_dataset import S3MapDataset
 from .s3checkpoint import S3Checkpoint
+from ._version import __version__
 
 __all__ = [
     "S3IterableDataset",
@@ -18,4 +19,5 @@ __all__ = [
     "S3Reader",
     "S3Writer",
     "S3Exception",
+    "__version__",
 ]

--- a/s3torchconnector/tst/unit/test_version.py
+++ b/s3torchconnector/tst/unit/test_version.py
@@ -1,0 +1,8 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+from s3torchconnector import __version__
+
+
+def test_connector_version():
+    assert isinstance(__version__, str)
+    assert __version__ > "1.0.0"

--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/__init__.py
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/__init__.py
@@ -5,7 +5,7 @@ import copyreg
 
 from ._logger_patch import TRACE as LOG_TRACE
 from ._logger_patch import _install_trace_logging
-from ._mountpoint_s3_client import S3Exception
+from ._mountpoint_s3_client import S3Exception, __version__
 
 _install_trace_logging()
 
@@ -16,7 +16,4 @@ def _s3exception_reduce(exc: S3Exception):
 
 copyreg.pickle(S3Exception, _s3exception_reduce)
 
-__all__ = [
-    "LOG_TRACE",
-    "S3Exception",
-]
+__all__ = ["LOG_TRACE", "S3Exception", "__version__"]

--- a/s3torchconnectorclient/python/tst/unit/test_mountpoint_s3_client.py
+++ b/s3torchconnectorclient/python/tst/unit/test_mountpoint_s3_client.py
@@ -3,9 +3,10 @@
 
 import logging
 import pickle
+import pytest
 from typing import Set
 
-import pytest
+from s3torchconnectorclient import LOG_TRACE, __version__
 from s3torchconnectorclient._mountpoint_s3_client import (
     S3Exception,
     GetObjectStream,
@@ -14,8 +15,6 @@ from s3torchconnectorclient._mountpoint_s3_client import (
     MockMountpointS3Client,
     MountpointS3Client,
 )
-
-from s3torchconnectorclient import LOG_TRACE
 
 logging.basicConfig(
     format="%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
@@ -291,3 +290,8 @@ def test_mountpoint_client_pickles():
 
 def _assert_isinstance(obj, expected: type):
     assert isinstance(obj, expected), f"Expected a {expected}, got {type(obj)=}"
+
+
+def test_client_version():
+    assert isinstance(__version__, str)
+    assert __version__ > "1.0.0"

--- a/s3torchconnectorclient/rust/src/lib.rs
+++ b/s3torchconnectorclient/rust/src/lib.rs
@@ -48,5 +48,6 @@ fn make_lib(py: Python, mountpoint_s3_client: &PyModule) -> PyResult<()> {
     mountpoint_s3_client.add_class::<PyObjectInfo>()?;
     mountpoint_s3_client.add_class::<PyRestoreStatus>()?;
     mountpoint_s3_client.add("S3Exception", py.get_type::<S3Exception>())?;
+    mountpoint_s3_client.add("__version__", build_info::FULL_VERSION)?;
     Ok(())
 }


### PR DESCRIPTION
Make version public for s3torchconnector and s3torchconnectorclient

## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
Add `__version__` to the public interface for both s3torchconnector and s3torchconnectorclient, to be easier for us to verify which version a customer is using.

## Testing
<!-- Please describe how these changes were tested. -->
- Unit tests
--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
