### PR TITLE
Expose function to enable debug logging

### DIFF
--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/__init__.py
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/__init__.py
@@ -4,7 +4,7 @@
 import copyreg
 
 from ._logger_patch import TRACE as LOG_TRACE
-from ._logger_patch import _install_trace_logging
+from ._logger_patch import _install_trace_logging, _enable_debug_logging
 from ._mountpoint_s3_client import S3Exception, __version__
 
 _install_trace_logging()
@@ -16,4 +16,4 @@ def _s3exception_reduce(exc: S3Exception):
 
 copyreg.pickle(S3Exception, _s3exception_reduce)
 
-__all__ = ["LOG_TRACE", "S3Exception", "__version__"]
+__all__ = ["LOG_TRACE", "S3Exception", "__version__", "_enable_debug_logging"]

--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/_logger_patch.py
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/_logger_patch.py
@@ -2,9 +2,19 @@
 #  // SPDX-License-Identifier: BSD
 
 import logging
+import atexit
+
+from ._mountpoint_s3_client import _enable_crt_logging, _disable_logging
 
 TRACE = 5
 
 
 def _install_trace_logging():
     logging.addLevelName(TRACE, "TRACE")
+
+
+# Experimental method for enabling verbose logging.
+# Please do NOT use unless otherwise instructed.
+def _enable_debug_logging():
+    atexit.register(_disable_logging)
+    _enable_crt_logging()

--- a/s3torchconnectorclient/rust/src/lib.rs
+++ b/s3torchconnectorclient/rust/src/lib.rs
@@ -4,6 +4,7 @@
  */
 
 use log::LevelFilter;
+use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
 use pyo3::prelude::*;
 use pyo3_log::Logger;
 
@@ -27,6 +28,24 @@ mod put_object_stream;
 mod python_structs;
 mod build_info;
 
+
+/// Experimental method to enable CRT logs for debugging purposes.
+/// Please do NOT call this method unless otherwise instructed.
+#[pyfunction]
+#[pyo3(name = "_enable_crt_logging")]
+fn _enable_crt_logging() {
+    let _ = RustLogAdapter::try_init().map_err(python_exception);
+}
+
+
+/// Experimental method to prevent deadlocks when enabling verbose CRT logging:
+/// https://docs.rs/pyo3-log/latest/pyo3_log/#interaction-with-python-gil
+#[pyfunction]
+#[pyo3(name = "_disable_logging")]
+fn _disable_logging() {
+    Logger::default().reset_handle();
+}
+
 #[pymodule]
 #[pyo3(name = "_mountpoint_s3_client")]
 fn make_lib(py: Python, mountpoint_s3_client: &PyModule) -> PyResult<()> {
@@ -49,5 +68,7 @@ fn make_lib(py: Python, mountpoint_s3_client: &PyModule) -> PyResult<()> {
     mountpoint_s3_client.add_class::<PyRestoreStatus>()?;
     mountpoint_s3_client.add("S3Exception", py.get_type::<S3Exception>())?;
     mountpoint_s3_client.add("__version__", build_info::FULL_VERSION)?;
+    mountpoint_s3_client.add_function(wrap_pyfunction!(_enable_crt_logging, mountpoint_s3_client)?)?;
+    mountpoint_s3_client.add_function(wrap_pyfunction!(_disable_logging, mountpoint_s3_client)?)?;
     Ok(())
 }


### PR DESCRIPTION
Experimental function to enable CRT logs for debug purposes

## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
We need a way to enhance our logging mechanism for debugging purposes. This PR adds a Python method that allows users to enable debug logs for our transitive client dependency, enhanced with a workaround for logging deadlocks known issue: https://docs.rs/pyo3-log/latest/pyo3_log/#interaction-with-python-gil

**This method is experimental and should not be used in production workloads.**

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->
When needed, `_enable_debug_logging()` can be called in a test to have more verbose client side logs. It will print request metrics such as: request id, request type, start/end timestamp, bucket name, error code, etc.


## Testing
<!-- Please describe how these changes were tested. -->
- Locally ran an E2E test together with the following Python logging settings:
```
from s3torchconnectorclient import LOG_TRACE, _enable_debug_logging

_enable_debug_logging()

logging.basicConfig(
    format="%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
)
logging.getLogger().setLevel(LOG_TRACE)
```

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).