### PR TITLE
Fix download/upload artifact failures

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,7 +41,11 @@ jobs:
           role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
           aws-region: ${{ vars.S3_REGION }}
 
-      - uses: actions/download-artifact@v4
+      # Downloading artifacts that were created from action/upload-artifact@v3 and below are not supported.
+      # https://github.com/actions/download-artifact
+      # These actions should remain @v3 for now, ignore dependabot proposed upgrade.
+      # https://github.com/actions/upload-artifact/issues/478
+      - uses: actions/download-artifact@v3
         with:
           name: "ort-results-s3connectorforpytorch--"
 
@@ -56,7 +60,7 @@ jobs:
         with:
           package-dir: s3torchconnectorclient
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: "./wheelhouse/*.whl"
           name: wheels
@@ -74,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: "ort-results-s3connectorforpytorch--"
 
@@ -91,7 +95,7 @@ jobs:
           python -m pip install build
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: "./${{ matrix.build_target }}/dist/*"
           name: wheels


### PR DESCRIPTION
Revert Github actions version upgraded with Dependabot

## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Downloading artifacts that were created from action/upload-artifact@v3 and below are not supported.
These should remain @v3 for now, ignore dependabot proposed upgrade.

## Related items
<!-- Please add related pull requests or Github issues. -->
- https://github.com/actions/download-artifact
- https://github.com/actions/upload-artifact/issues/478

## Testing
<!-- Please describe how these changes were tested. -->

https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/7584136329

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
