### PR TITLE
Generate wheels/third party licenses on push to main, dependabot, or …

### DIFF
--- a/.github/workflows/generate_third_party_licenses.yml
+++ b/.github/workflows/generate_third_party_licenses.yml
@@ -3,6 +3,7 @@ name: Generate THIRD-PARTY-LICENSES
 on:
   push:
     tags: [ "v[0-9]+.[0-9]+.[0-9]+" ]
+    branches: [ "dependabot/*", "main", "workflow/*" ]
   workflow_call:
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,6 +3,7 @@ name: Build Wheels
 on:
   push:
     tags: [ "v[0-9]+.[0-9]+.[0-9]+" ]
+    branches: [ "dependabot/*", "main", "workflow/*" ]
 
 env:
   S3_REGION: ${{ vars.S3_REGION }}


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Run wheels/third party license Github Actions when pushed to dependabot, main, or dedicated `workflow/*` branches. This will allow us to test if changes we are making break our release CI before merging in, or soon after in case we're merging from a pull request.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

Previously, when merging dependabot PRs, we discovered some had breaking changes that weren't failing our normal CI as they were only tested in our actual release process. Running these tests before a merge allows us to prevent the problematic merge in the first place, and allows us to continue merging in dependabot PRs without excessive overhead.

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

Pushed to a custom workflow branch and saw it ran the wheel and third party licenses tests.

https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/7697956559

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
