### PR TITLE
Added support for passing S3 endpoint as an argument to dataset construction API to access dataset stored in AWS S3 compatible storage systems

### DIFF
--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -28,8 +28,9 @@ def _identity(obj: Any) -> Any:
 
 
 class S3Client:
-    def __init__(self, region: str):
+    def __init__(self, region: str, endpoint: str = ""):
         self._region = region
+        self._endpoint = endpoint
         self._real_client = None
         self._client_pid = None
 
@@ -47,7 +48,9 @@ class S3Client:
 
     def _client_builder(self) -> MountpointS3Client:
         return MountpointS3Client(
-            region=self._region, user_agent_prefix=user_agent_prefix
+            region=self._region,
+            endpoint=self._endpoint,
+            user_agent_prefix=user_agent_prefix,
         )
 
     def get_object(self, bucket: str, key: str) -> S3Reader:

--- a/s3torchconnector/src/s3torchconnector/s3checkpoint.py
+++ b/s3torchconnector/src/s3torchconnector/s3checkpoint.py
@@ -16,8 +16,9 @@ class S3Checkpoint:
     torch.load, and torch.save.
     """
 
-    def __init__(self, region: str):
+    def __init__(self, region: str, endpoint: str = ""):
         self.region = region
+        self.endpoint = endpoint
         self._client = S3Client(region)
 
     def reader(self, s3_uri: str) -> S3Reader:

--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/_mountpoint_s3_client.pyi
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/_mountpoint_s3_client.pyi
@@ -16,6 +16,7 @@ class MountpointS3Client:
     def __init__(
         self,
         region: str,
+        endpoint: str,
         user_agent_prefix: str = "",
         throughput_target_gbps: float = 10.0,
         part_size: int = 8 * 1024 * 1024,
@@ -35,6 +36,7 @@ class MockMountpointS3Client:
     def __init__(
         self,
         region: str,
+        endpoint: str,
         bucket: str,
         throughput_target_gbps: float = 10.0,
         part_size: int = 8 * 1024 * 1024,

--- a/s3torchconnectorclient/rust/src/mock_client.rs
+++ b/s3torchconnectorclient/rust/src/mock_client.rs
@@ -51,6 +51,7 @@ impl PyMockClient {
     fn create_mocked_client(&self) -> MountpointS3Client {
         MountpointS3Client::new(
             self.region.clone(),
+            "".to_string(),
             "mock-client".to_string(),
             self.throughput_target_gbps,
             self.part_size,


### PR DESCRIPTION

## Description
Provide a way to pass endpoint as an optional argument to the dataset manipulation API classes S3MapDataset, S3IterableDataset, and S3Checkpoint. To support this new optional argument, modified Rust client code MountpointS3Client. By default the argument is set to empty string. In the  MountpointS3Client, the endpoint is set in EndpointConfig if it is not empty. With this change the pytorch s3 connector can work with AWS S3 compatible storage systems.

## Additional context
Current pytorch s3 connector can only work with AWS S3 service as it by default connects to AWS S3 endpoint. Only the region parameter can be passed. In order to work with datasets stored in AWS S3 compatible storage systems, endpoint needs to be changed. 

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
Tested with example code of accessing datasets using S3MapDataset, S3IterableDataset and saving checkpoints using S3Checkpoint. Tested with empty and non-empty endpoint argument.
--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
