### PR TITLE
Fix wheel generation artefact name

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,6 +35,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Initialise environment
+        shell: bash
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          REPO_NAME_SAFE=$(echo $REPO_NAME | sed -e 's/[^A-Za-z0-9 \-\_]//g' -e 's/\s/-/g' -e 's/\([A-Z]\)/\L\1/g')
+          ARTIFACT_NAME="ort-results-${REPO_NAME_SAFE}--"
+          export ARTIFACT_NAME
+          printenv >> "$GITHUB_ENV"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         id: creds
@@ -48,7 +58,7 @@ jobs:
       # https://github.com/actions/upload-artifact/issues/478
       - uses: actions/download-artifact@v3
         with:
-          name: "ort-results-${{ github.event.repository.name }}--"
+          name: ${{ ARTIFACT_NAME }}
 
       - name: Rename third party license
         run: |
@@ -81,7 +91,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: "ort-results-${{ github.event.repository.name }}--"
+          name: ${{ ARTIFACT_NAME }}
 
       - name: Copy license files
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
       # https://github.com/actions/upload-artifact/issues/478
       - uses: actions/download-artifact@v3
         with:
-          name: "ort-results-s3connectorforpytorch--"
+          name: "ort-results-${{ github.event.repository.name }}--"
 
       - name: Rename third party license
         run: |
@@ -81,7 +81,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: "ort-results-s3connectorforpytorch--"
+          name: "ort-results-${{ github.event.repository.name }}--"
 
       - name: Copy license files
         run: |


### PR DESCRIPTION
## Description

Stop using a hardcoded artefact name, and use the same generation process ORT uses for it's own artefact name generation.

## Additional context

Third party license generation/wheel workflows were not working in forked repositories. This change fixes this.

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing

Tested on a workflow in a private fork

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
