### PR TITLE
Fix wheel import of third party licenses

### DIFF
--- a/.github/workflows/generate_third_party_licenses.yml
+++ b/.github/workflows/generate_third_party_licenses.yml
@@ -5,11 +5,18 @@ on:
     tags: [ "v[0-9]+.[0-9]+.[0-9]+" ]
     branches: [ "dependabot/*", "main", "workflow/*" ]
   workflow_call:
+    outputs:
+      artifact_name:
+        description: "The created artifact name for ORT results"
+        value: ${{ jobs.generate_third_party_licenses.outputs.artifact_name }}
 
 jobs:
   generate_third_party_licenses:
     name: Generate NOTICE_DEFAULT file
     runs-on: ubuntu-20.04
+
+    outputs:
+      artifact_name: ${{ steps.artifact_name.outputs.artifact_name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -38,3 +45,8 @@ jobs:
             reporter,
             upload-results
           sw-version: "-"
+
+      - name: Export artifact name
+        id: artifact_name
+        run: |
+          echo "artifact_name=${ORT_RESULTS_ARTIFACT_NAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,17 +34,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Initialise environment
-        shell: bash
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
-          REPO_NAME_SAFE=$(echo $REPO_NAME | sed -e 's/[^A-Za-z0-9 \-\_]//g' -e 's/\s/-/g' -e 's/\([A-Z]\)/\L\1/g')
-          ARTIFACT_NAME="ort-results-${REPO_NAME_SAFE}--"
-          export ARTIFACT_NAME
-          printenv >> "$GITHUB_ENV"
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         id: creds
@@ -58,7 +47,7 @@ jobs:
       # https://github.com/actions/upload-artifact/issues/478
       - uses: actions/download-artifact@v3
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ needs.generate_third_party_licenses.outputs.artifact_name }}
 
       - name: Rename third party license
         run: |
@@ -91,7 +80,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ needs.generate_third_party_licenses.outputs.artifact_name }}
 
       - name: Copy license files
         run: |


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

The wheel generation workflow was failing due to an issue with how the third party license name was being generated. Instead of running a regex to decide what it was called, export the environment variable across workflows so we know we always have the right name.

It was failing previously because `GITHUB_ENV` is not kept across workflows.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

No breaking changes.

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

Wheel generation workflow now passes

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
