### PR TITLE
Use `pytest.raises` with match everywhere

### DIFF
--- a/s3torchconnector/tst/unit/test_s3dataset_common.py
+++ b/s3torchconnector/tst/unit/test_s3dataset_common.py
@@ -116,7 +116,7 @@ def test_get_objects_from_uris_success(
 def test_get_objects_from_uris_fail(uri, error_msg):
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, [])
     with pytest.raises(ValueError, match=f"^{error_msg}$"):
-         get_objects_from_uris(uri, mock_client)
+        get_objects_from_uris(uri, mock_client)
 
 
 def _create_mock_client_with_dummy_objects(

--- a/s3torchconnector/tst/unit/test_s3dataset_common.py
+++ b/s3torchconnector/tst/unit/test_s3dataset_common.py
@@ -53,9 +53,8 @@ def test_s3dataset_base_parse_s3_uri_success(uri, expected_bucket, expected_key)
     ],
 )
 def test_s3dataset_base_parse_s3_uri_fail(uri, error_msg):
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(ValueError, match=f"^{error_msg}$"):
         parse_s3_uri(uri)
-    assert str(error.value) == error_msg
 
 
 @pytest.mark.parametrize(
@@ -79,13 +78,12 @@ def test_get_objects_from_prefix(prefix: str, keys: Sequence[str], expected_coun
 
 def test_list_objects_for_bucket_invalid():
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, [])
-    with pytest.raises(S3Exception) as error:
+    with pytest.raises(S3Exception, match="Service error: The bucket does not exist"):
         objects = get_objects_from_prefix(
             "s3://DIFFERENT_BUCKET",
             mock_client,
         )
         next(iter(objects))
-    assert str(error.value) == "Service error: The bucket does not exist"
 
 
 @pytest.mark.parametrize(
@@ -117,9 +115,8 @@ def test_get_objects_from_uris_success(
 )
 def test_get_objects_from_uris_fail(uri, error_msg):
     mock_client = _create_mock_client_with_dummy_objects(TEST_BUCKET, [])
-    with pytest.raises(ValueError) as error:
-        objects = get_objects_from_uris(uri, mock_client)
-    assert str(error.value) == error_msg
+    with pytest.raises(ValueError, match=f"^{error_msg}$"):
+         get_objects_from_uris(uri, mock_client)
 
 
 def _create_mock_client_with_dummy_objects(

--- a/s3torchconnector/tst/unit/test_s3reader.py
+++ b/s3torchconnector/tst/unit/test_s3reader.py
@@ -73,9 +73,8 @@ def test_s3reader_creation(object_info, get_stream):
     [(None, None), (None, ""), (None, TEST_KEY), ("", TEST_KEY)],
 )
 def test_s3reader_invalid_creation(bucket, key):
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(ValueError, match="Bucket should be specified"):
         S3Reader(bucket, key)
-    assert str(error.value) == "Bucket should be specified"
 
 
 @pytest.mark.parametrize(

--- a/s3torchconnectorclient/python/tst/integration/test_mountpoint_s3_integration.py
+++ b/s3torchconnectorclient/python/tst/integration/test_mountpoint_s3_integration.py
@@ -54,24 +54,22 @@ def test_get_object_with_unpickled_client(sample_directory):
 
 def test_get_object_invalid_bucket(sample_directory):
     client = MountpointS3Client(sample_directory.region, TEST_USER_AGENT_PREFIX)
-    with pytest.raises(S3Exception) as error:
+    with pytest.raises(S3Exception, match="Service error: The bucket does not exist"):
         next(
             client.get_object(
                 f"{sample_directory.bucket}-{uuid.uuid4()}", sample_directory.prefix
             )
         )
-    assert str(error.value) == "Service error: The bucket does not exist"
 
 
 def test_get_object_invalid_prefix(sample_directory):
     client = MountpointS3Client(sample_directory.region, TEST_USER_AGENT_PREFIX)
-    with pytest.raises(S3Exception) as error:
+    with pytest.raises(S3Exception, match="Service error: The key does not exist"):
         next(
             client.get_object(
                 sample_directory.bucket, f"{sample_directory.prefix}-{uuid.uuid4()}"
             )
         )
-    assert str(error.value) == "Service error: The key does not exist"
 
 
 def test_list_objects(image_directory):

--- a/s3torchconnectorclient/python/tst/unit/test_mountpoint_s3_client.py
+++ b/s3torchconnectorclient/python/tst/unit/test_mountpoint_s3_client.py
@@ -66,32 +66,24 @@ def test_get_object_bad_bucket():
     mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
     client = mock_client.create_mocked_client()
 
-    try:
+    with pytest.raises(S3Exception, match="Service error: The bucket does not exist"):
         client.get_object("does_not_exist", "foo")
-    except S3Exception as e:
-        assert str(e) == "Service error: The bucket does not exist"
 
 
 def test_get_object_none_bucket():
     mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
     client = mock_client.create_mocked_client()
 
-    try:
+    with pytest.raises(TypeError):
         client.get_object(None, "foo")
-    except TypeError:
-        pass
-    else:
-        raise AssertionError("Should raise TypeError")
 
 
 def test_get_object_bad_object():
     mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
     client = mock_client.create_mocked_client()
 
-    try:
+    with pytest.raises(S3Exception, match="Service error: The key does not exist"):
         client.get_object(MOCK_BUCKET, "does_not_exist")
-    except S3Exception as e:
-        assert str(e) == "Service error: The key does not exist"
 
 
 def test_get_object_iterates_once():
@@ -121,12 +113,8 @@ def test_get_object_throws_stop_iteration():
         pass
 
     for _ in range(10):
-        try:
+        with pytest.raises(StopIteration):
             next(stream)
-        except StopIteration:
-            pass
-        else:
-            raise AssertionError("Should always throw StopIteration after stream ends")
 
 
 @pytest.mark.parametrize(
@@ -224,9 +212,8 @@ def test_put_object_no_multiple_close():
 
     put_stream.write(b"")
     put_stream.close()
-    with pytest.raises(S3Exception) as e:
+    with pytest.raises(S3Exception, match="Cannot close object more than once"):
         put_stream.close()
-    assert str(e.value) == "Cannot close object more than once"
 
 
 def test_put_object_no_write_after_close():
@@ -238,9 +225,8 @@ def test_put_object_no_write_after_close():
 
     put_stream.write(b"")
     put_stream.close()
-    with pytest.raises(S3Exception) as e:
+    with pytest.raises(S3Exception, match="Cannot write to closed object"):
         put_stream.write(b"")
-    assert str(e.value) == "Cannot write to closed object"
 
 
 def test_put_object_with_storage_class():


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Previously we had a mix and match of usage of raw `try`/`except` and `pytest.raises` without match blocks. As we decided we like `pytest.raises` with match, this commit makes us consistent across the repository

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

No breaking changes

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing

Tests still pass

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
