### PR TITLE
Revert cc to 1.0.83 to fix wheels build workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,7 +54,7 @@ jobs:
           mv NOTICE_DEFAULT THIRD-PARTY-LICENSES
 
       - name: Build wheels for s3torchconnectorclient
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: ${{ matrix.build_target }}
         with:

--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -156,10 +156,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.85"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b918671670962b48bc23753aef0c51d072dca6f52f01f800854ada6ddb7f7d3"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -483,6 +484,15 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"

--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -68,7 +68,7 @@ skip = "*musllinux* *i686"
 
 [tool.cibuildwheel.linux]
 before-all = [
-  "curl https://sh.rustup.rs -sSf | sh -s -- -y",
+  "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
   "yum install -y epel-release centos-release-scl",
   "yum install -y fuse",
   "yum install -y fuse-devel",

--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -68,7 +68,7 @@ skip = "*musllinux* *i686"
 
 [tool.cibuildwheel.linux]
 before-all = [
-  "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
+  "curl https://sh.rustup.rs -sSf | sh -s -- -y",
   "yum install -y epel-release centos-release-scl",
   "yum install -y fuse",
   "yum install -y fuse-devel",


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
Revert cc to 1.0.83 to fix wheels build workflow


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->
We were seeing [this error](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/7889988102/job/21531280591) after a Cargo update:
```
[  0%] Generating curve25519/curve25519_x25519base_alt.S.S
        
          --- stderr
          libunwind not found. Disabling unwind tests.
          Copying platform assembly files from /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mountpoint-s3-crt-sys-0.5.3/crt/aws-lc/generated-src/linux-x86_64/crypto/ to /project/s3torchconnectorclient/target/release/build/mountpoint-s3-crt-sys-24feb138cf4a244b/out/build/aws-lc/build/crypto
          gmake[1]: *** read jobs pipe: Resource temporarily unavailable.  Stop.
          gmake[1]: *** Waiting for unfinished jobs....
          gmake[2]: *** read jobs pipe: Resource temporarily unavailable.  Stop.
          gmake[2]: *** Waiting for unfinished jobs....
          gmake[1]: *** [crypto/fipsmodule/CMakeFiles/fipsmodule.dir/all] Error 2
          gmake: *** [all] Error 2
          thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cmake-0.1.50/src/lib.rs:1098:5:
        
          command did not execute successfully, got: exit status: 2
        
          build script failed, must exit now
          note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
        warning: build failed, waiting for other jobs to finish...
        cargo rustc --lib --message-format=json-render-diagnostics --manifest-path Cargo.toml --release -v --features pyo3/extension-module --crate-type cdylib --
        error: `cargo rustc --lib --message-format=json-render-diagnostics --manifest-path Cargo.toml --release -v --features pyo3/extension-module --crate-type cdylib --` failed with code 101
        [end of output]
```

We have updated the `cc` crate, which is:
> A build-time dependency for Cargo build scripts to assist in invoking the native C compiler to compile native C code into a static archive to be linked into Rust code.”

We were using cc [1.0.85](https://docs.rs/cc/1.0.85/cc/index.html#), that was causing the failure (and had different Github issues such as: https://github.com/rust-lang/cc-rs/issues/948).

The owners for cc yanked the previous [2 revisions](https://crates.io/crates/cc/versions), so reverting back to 1.0.83 resolved the issue on our end, but with this occasion we learned that there are multiple crates depending on cc, including cmake and CRT.

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->
- https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/7890651438
--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
