### PR TITLE
Remove extra HeadObject call in from_prefix

### DIFF
--- a/s3torchconnector/src/s3torchconnector/_s3bucket_key_data.py
+++ b/s3torchconnector/src/s3torchconnector/_s3bucket_key_data.py
@@ -1,10 +1,13 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
-from typing import NamedTuple
+from typing import NamedTuple, Optional
+
+from s3torchconnectorclient._mountpoint_s3_client import ObjectInfo
 
 
-class S3BucketKey(NamedTuple):
+class S3BucketKeyData(NamedTuple):
     """Read-only information about object stored in S3."""
 
     bucket: str
     key: str
+    object_info: Optional[ObjectInfo] = None

--- a/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
+++ b/s3torchconnector/src/s3torchconnector/_s3dataset_common.py
@@ -6,7 +6,7 @@ from typing import Iterable, Union, Tuple
 from ._s3_bucket_iterable import S3BucketIterable
 from ._s3client import S3Client
 from . import S3Reader
-from ._s3bucket_key import S3BucketKey
+from ._s3bucket_key_data import S3BucketKeyData
 
 """
 _s3dataset_common.py
@@ -38,18 +38,15 @@ def parse_s3_uri(uri: str) -> Tuple[str, str]:
 
 def get_objects_from_uris(
     object_uris: Union[str, Iterable[str]], client: S3Client
-) -> Iterable[S3BucketKey]:
+) -> Iterable[S3BucketKeyData]:
     if isinstance(object_uris, str):
         object_uris = [object_uris]
     # TODO: We should be consistent with URIs parsing. Revise if we want to do this upfront or lazily.
     bucket_key_pairs = [parse_s3_uri(uri) for uri in object_uris]
 
-    return (S3BucketKey(bucket, key) for bucket, key in bucket_key_pairs)
+    return (S3BucketKeyData(bucket, key) for bucket, key in bucket_key_pairs)
 
 
-def get_objects_from_prefix(s3_uri: str, client: S3Client) -> Iterable[S3BucketKey]:
+def get_objects_from_prefix(s3_uri: str, client: S3Client) -> Iterable[S3BucketKeyData]:
     bucket, prefix = parse_s3_uri(s3_uri)
-    s3objects = S3BucketIterable(client, bucket, prefix)
-    bucket_key_pairs = (S3BucketKey(obj.bucket, obj.key) for obj in s3objects)
-
-    return bucket_key_pairs
+    return iter(S3BucketIterable(client, bucket, prefix))

--- a/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3iterable_dataset.py
@@ -7,7 +7,7 @@ import logging
 import torch.utils.data
 
 from . import S3Reader
-from ._s3bucket_key import S3BucketKey
+from ._s3bucket_key_data import S3BucketKeyData
 from ._s3client import S3Client
 from ._s3dataset_common import (
     identity,
@@ -28,7 +28,7 @@ class S3IterableDataset(torch.utils.data.IterableDataset):
     def __init__(
         self,
         region: str,
-        get_dataset_objects: Callable[[S3Client], Iterable[S3BucketKey]],
+        get_dataset_objects: Callable[[S3Client], Iterable[S3BucketKeyData]],
         endpoint: str = None,
         transform: Callable[[S3Reader], Any] = identity,
     ):
@@ -113,9 +113,11 @@ class S3IterableDataset(torch.utils.data.IterableDataset):
             self._client = S3Client(self.region, self.endpoint)
         return self._client
 
-    def _get_transformed_object(self, bucket_key: S3BucketKey) -> Any:
+    def _get_transformed_object(self, bucket_key: S3BucketKeyData) -> Any:
         return self._transform(
-            self._get_client().get_object(bucket_key.bucket, bucket_key.key)
+            self._get_client().get_object(
+                bucket_key.bucket, bucket_key.key, object_info=bucket_key.object_info
+            )
         )
 
     def __iter__(self) -> Iterator[Any]:

--- a/s3torchconnector/src/s3torchconnector/s3map_dataset.py
+++ b/s3torchconnector/src/s3torchconnector/s3map_dataset.py
@@ -5,7 +5,7 @@ from typing import List, Any, Callable, Iterable, Union
 import logging
 
 import torch.utils.data
-from s3torchconnector._s3bucket_key import S3BucketKey
+from s3torchconnector._s3bucket_key_data import S3BucketKeyData
 
 from ._s3client import S3Client
 from . import S3Reader
@@ -29,7 +29,7 @@ class S3MapDataset(torch.utils.data.Dataset):
     def __init__(
         self,
         region: str,
-        get_dataset_objects: Callable[[S3Client], Iterable[S3BucketKey]],
+        get_dataset_objects: Callable[[S3Client], Iterable[S3BucketKeyData]],
         endpoint: str = None,
         transform: Callable[[S3Reader], Any] = identity,
     ):
@@ -49,7 +49,7 @@ class S3MapDataset(torch.utils.data.Dataset):
         return self._endpoint
 
     @property
-    def _dataset_bucket_key_pairs(self) -> List[S3BucketKey]:
+    def _dataset_bucket_key_pairs(self) -> List[S3BucketKeyData]:
         if self._bucket_key_pairs is None:
             self._bucket_key_pairs = list(self._get_dataset_objects(self._get_client()))
         return self._bucket_key_pairs
@@ -123,7 +123,9 @@ class S3MapDataset(torch.utils.data.Dataset):
 
     def _get_object(self, i: int) -> S3Reader:
         bucket_key = self._dataset_bucket_key_pairs[i]
-        return self._get_client().get_object(bucket_key.bucket, bucket_key.key)
+        return self._get_client().get_object(
+            bucket_key.bucket, bucket_key.key, object_info=bucket_key.object_info
+        )
 
     def __getitem__(self, i: int) -> Any:
         return self._transform(self._get_object(i))

--- a/s3torchconnector/tst/unit/test_s3_client.py
+++ b/s3torchconnector/tst/unit/test_s3_client.py
@@ -1,11 +1,11 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 import logging
+from unittest.mock import MagicMock
 
 import pytest
 
 from s3torchconnector._s3client import S3Client, MockS3Client
-from s3torchconnectorclient._mountpoint_s3_client import ObjectInfo
 
 TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key"
@@ -23,16 +23,13 @@ def s3_client() -> S3Client:
 def test_get_object_log(s3_client: S3Client, caplog):
     with caplog.at_level(logging.DEBUG):
         s3_client.get_object(TEST_BUCKET, TEST_KEY)
-    assert f"GetObject {S3_URI}" in caplog.messages
+    assert f"GetObject {S3_URI}, object_info is None=True" in caplog.messages
 
 
-def test_get_object_info_log(s3_client: S3Client, caplog):
+def test_get_object_log_with_info(s3_client: S3Client, caplog):
     with caplog.at_level(logging.DEBUG):
-        s3_client.from_bucket_and_object_info(
-            TEST_BUCKET,
-            ObjectInfo(TEST_KEY, "", 0, 0, None, None),
-        )
-    assert f"GetObjectWithInfo {S3_URI}" in caplog.messages
+        s3_client.get_object(TEST_BUCKET, TEST_KEY, object_info=MagicMock())
+    assert f"GetObject {S3_URI}, object_info is None=False" in caplog.messages
 
 
 def test_head_object_log(s3_client: S3Client, caplog):

--- a/s3torchconnector/tst/unit/test_s3iterable_dataset.py
+++ b/s3torchconnector/tst/unit/test_s3iterable_dataset.py
@@ -1,11 +1,14 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 import logging
+from io import SEEK_END
 from typing import Iterable, Callable, Sequence, Any
+from unittest.mock import patch
 
 import pytest
 
 from s3torchconnector import S3IterableDataset, S3Reader
+from s3torchconnector._s3client import MockS3Client
 
 from test_s3dataset_common import (
     TEST_BUCKET,
@@ -198,6 +201,21 @@ def test_dataset_creation_from_prefix_with_region_and_endpoint():
     )
     assert isinstance(dataset, S3IterableDataset)
     assert dataset.endpoint == TEST_ENDPOINT
+
+
+def test_from_prefix_seek_no_head():
+    dataset = S3IterableDataset.from_prefix(S3_PREFIX, region=TEST_REGION)
+
+    # use mock client for unit testing
+    client = _create_mock_client_with_dummy_objects(TEST_BUCKET, ["foo"])
+    dataset._client = client
+
+    with patch.object(
+        MockS3Client, "head_object", wraps=client.head_object
+    ) as head_object:
+        s3_object = next(iter(dataset))
+        s3_object.seek(0, SEEK_END)
+    head_object.assert_not_called()
 
 
 def _verify_dataset(


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

- Ensure HeadObject is not explicitly called when seeking to the end of a file when dataset is created with from_prefix
- Rename `S3BucketKey` to `S3BucketKeyData`
- Change signature of `iter(S3BucketIterable)` to `Iterator[S3BucketData]` instead of `Iterator[S3Reader]`

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

No breaking changes

## Related items
<!-- Please add related pull requests or Github issues. -->

https://github.com/awslabs/s3-connector-for-pytorch/issues/133

## Testing
<!-- Please describe how these changes were tested. -->

Extra tests added which verify that `head_object` is not called when seeking to the end of an S3Object when created using `from_prefix` for either dataset.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
