### PR TITLE
Fix check on the number of passing parameters in build script

### DIFF
--- a/run_cibuildwheel_on_ec2.sh
+++ b/run_cibuildwheel_on_ec2.sh
@@ -1,6 +1,6 @@
-if [ $# -ne 6 ]; then
-    echo "Invalid number of parameters, you need to provide role name, region name, bucket name, prefix, express region name and express bucket name"
-    echo "Usage: $0 S3RoleName us-west-2 s3torchconnector-test-bucket-name prefix-name/ us-east-1 s3torchconnectorclient-express-bucket-name"
+if [ $# -ne 7 ]; then
+    echo "Invalid number of parameters, you need to provide role name, region name, bucket name, prefix, express region name and express bucket name, custom endpoint for s3 standard"
+    echo "Usage: $0 S3RoleName us-west-2 s3torchconnector-test-bucket-name prefix-name/ us-east-1 s3torchconnectorclient-express-bucket-name https://s3.amazon.com"
     exit 1
 fi
 


### PR DESCRIPTION
## Description
Build script is not allowing to pass custom s3 endpoint, because of initial check on the number of passed parameters.
Updated check to requires seven input parameters for the build script.

## Testing
Run the build script to confirm that it is working

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
