### PR TITLE
Add ARM runners to the CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,17 +18,22 @@ jobs:
     uses: ./.github/workflows/generate_third_party_licenses.yml
 
   build_wheels:
-    name: Build wheels for ${{ matrix.build_target }}
-    runs-on: ubuntu-20.04
+    name: Build wheels for ${{ matrix.build_prefix }} - ${{ matrix.builder.arch }}
+    runs-on: ${{ matrix.builder.runner }}
     needs: generate_third_party_licenses
     strategy:
       matrix:
-        build_target:
-          - cp38-manylinux_x86_64
-          - cp39-manylinux_x86_64
-          - cp310-manylinux_x86_64
-          - cp311-manylinux_x86_64
-          - cp312-manylinux_x86_64
+        build_prefix:
+          - cp38
+          - cp39
+          - cp310
+          - cp311
+          - cp312
+        builder:
+          - runner: codebuild-ubuntu-large
+            arch: x86_64
+          - runner: codebuild-arm-large
+            arch: aarch64
     permissions:
       id-token: write
       contents: read
@@ -54,12 +59,27 @@ jobs:
         run: |
           mv NOTICE_DEFAULT THIRD-PARTY-LICENSES
 
-      - name: Build wheels for s3torchconnectorclient
-        uses: pypa/cibuildwheel@v2.16.5
-        env:
-          CIBW_BUILD: ${{ matrix.build_target }}
+      # actions/setup-python doesn't yet support ARM
+      # https://github.com/actions/setup-python/issues/678
+      - if: ${{ matrix.builder.arch != 'aarch64' }}
+        uses: actions/setup-python@v4
         with:
-          package-dir: s3torchconnectorclient
+          python-version: "3.11"
+
+      - name: Install pipx
+        run: |
+          python -m pip install --upgrade pipx 
+
+      # Run cibuildwheel manually, as the current runner uses setup-python
+      # https://github.com/pypa/cibuildwheel/issues/1623
+      - run: >
+          python -m pipx run
+          cibuildwheel
+          "s3torchconnectorclient"
+          --output-dir "wheelhouse"
+          --only "${{ matrix.build_prefix }}-manylinux_${{ matrix.builder.arch }}"
+          2>&1
+        shell: bash
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,9 +30,9 @@ jobs:
           - cp311
           - cp312
         builder:
-          - runner: codebuild-ubuntu-large
+          - runner: codebuild-${{ github.event.repository.name }}-ubuntu-7.0-large
             arch: x86_64
-          - runner: codebuild-arm-large
+          - runner: codebuild-${{ github.event.repository.name }}-arm-3.0-large
             arch: aarch64
     permissions:
       id-token: write

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,9 +30,9 @@ jobs:
           - cp311
           - cp312
         builder:
-          - runner: codebuild-${{ github.event.repository.name }}-ubuntu-7.0-large
+          - runner: codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-ubuntu-7.0-large
             arch: x86_64
-          - runner: codebuild-${{ github.event.repository.name }}-arm-3.0-large
+          - runner: codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-arm-3.0-large
             arch: aarch64
     permissions:
       id-token: write


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

- Automatically build ARM wheels in our CI with codebuild
- Also migrate x86 wheel builds to codebuild
- Total wheel build improved from 20-30 minutes to ~15 minutes


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

No breaking changes

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

Passed workflow: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/7991821909
Wheels artifact includes x86, arm, and source wheels.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
