### PR TITLE
Use cpu wheel for torchvision

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # Manually install CPU-only version of torch so we're not carrying around giant GPU drivers/kernels
-          python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
+          python -m pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
           python -m pip install -e "s3torchconnectorclient[test]"
           python -m pip install -e "s3torchconnector[test]"
           python -m pip install -e "s3torchbenchmarking[test]"

--- a/s3torchbenchmarking/pyproject.toml
+++ b/s3torchbenchmarking/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.8,<3.12"
 readme = "README.md"
 dependencies = [
     "torch >= 2.0.1",
-    "s3torchconnector>=1.1.1",
+    "s3torchconnector",
     "hydra-core",
     "torchdata>=0.6.1",
     "torchvision",


### PR DESCRIPTION
## Description
Making it compatible with the installed torch version. Addresses build failures of the kind:

```
RuntimeError: operator torchvision::nms does not exist
```

Also, remove unnecessary s3torchconnector version constraint.


## Related items
- [Addresses failing jobs like this one](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/8018083826/job/21903264299)

## Testing
- Created a virtualenv like the GH action would and was able to repro the issue locally. Tested that the fix works.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
