### PR TITLE
Support benchmarking mountpoint-backed datasets

### DIFF
--- a/s3torchbenchmarking/README.md
+++ b/s3torchbenchmarking/README.md
@@ -75,6 +75,17 @@ Then from this directory, install the dependencies:
 This would make the `s3torch-benchmark` and `s3torch-datagen` commands available to you. Note: the installation would
 recommend $PATH modifications if necessary, allowing you to use the commands directly.
 
+**(Optional) Install Mountpoint**
+
+Required only if you're running benchmarks using PyTorch with Mountpoint for S3.
+
+    wget https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.rpm
+    sudo yum install ./mount-s3.rpm # For an RHEL system
+
+For other distros see [Installing Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3/blob/main/doc/INSTALL.md).
+
+_Note: Mountpoint benchmarks are currently only supported on *nix-based systems and rely on `sudo` capabilities._  
+
 ### (Pre-requisite) Configure AWS Credentials
 
 The commands provided below(`datagen.py`, `benchmark.py`) rely on the standard [AWS credential discovery mechanism](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html). 

--- a/s3torchbenchmarking/conf/dataloader/mountpoint.yaml
+++ b/s3torchbenchmarking/conf/dataloader/mountpoint.yaml
@@ -1,0 +1,3 @@
+kind: mountpoint
+batch_size: 128
+num_workers: 8

--- a/s3torchbenchmarking/src/s3torchbenchmarking/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/benchmark.py
@@ -1,19 +1,23 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
-
-
+import atexit
+import shutil
+import subprocess
+import tempfile
 from enum import Enum
-from typing import Optional
+from pathlib import Path
+from typing import Optional, List
 
 import hydra
 import torchdata
 from omegaconf import DictConfig
-from s3torchconnector import S3IterableDataset, S3Reader, S3MapDataset
 from torch.utils.data import DataLoader, Dataset, default_collate
 from torchdata.datapipes.utils import StreamWrapper
 
 from s3torchbenchmarking.benchmark_utils import ResourceMonitor
 from s3torchbenchmarking.models import Entitlement, ViT, ModelInterface
+from s3torchconnector import S3IterableDataset, S3Reader, S3MapDataset
+from s3torchconnector._s3dataset_common import parse_s3_uri
 
 
 @hydra.main(version_base=None)
@@ -71,6 +75,27 @@ class DatasetSharding(Enum):
             return DatasetSharding[dataset_config.sharding]
 
 
+def make_mountpoint(
+    prefix_uri: str,
+    mountpoint_path: Optional[str] = None,
+    additional_args: List[str] = None,
+) -> str:
+    def teardown(path: str):
+        subprocess.run(["sudo", "umount", path])
+        shutil.rmtree(path)
+
+    bucket, prefix = parse_s3_uri(prefix_uri)
+    # Run Mountpoint in background mode, and arrange for it to unmount when this script exits
+    tempdir = tempfile.mkdtemp(prefix="s3dataset_")
+    binary = mountpoint_path or "mount-s3"
+    args = additional_args or []
+    subprocess.run([binary, bucket, tempdir] + args, check=True)
+    atexit.register(teardown, tempdir)
+
+    # Now we can just read our dataset as if it were a local directory
+    return str(Path(tempdir) / prefix)
+
+
 def make_dataset(
     kind: str,
     sharding: Optional[DatasetSharding],
@@ -80,32 +105,71 @@ def make_dataset(
     num_workers: int,
 ):
     if kind == "s3iterabledataset":
-        dataset = S3IterableDataset.from_prefix(prefix_uri, region=region)
-        dataset = torchdata.datapipes.iter.IterableWrapper(dataset)
-        if num_workers > 0:
-            dataset = dataset.sharding_filter()
-        if sharding == DatasetSharding.TAR:
-            dataset = dataset.map(tar_to_tuple)
-            dataset = dataset.load_from_tar()
-        return dataset.map(load_sample)
+        return create_s3_iterable_dataset(
+            sharding, prefix_uri, region, load_sample, num_workers
+        )
     elif kind == "s3mapdataset":
-        if sharding:
-            raise ValueError(f"Sharding is not supported for {kind}")
-        else:
-            dataset = S3MapDataset.from_prefix(
-                prefix_uri, region=region, transform=load_sample
-            )
-            return dataset
+        return create_s3_map_dataset(sharding, prefix_uri, region, load_sample)
     elif kind == "fsspec":
-        lister = torchdata.datapipes.iter.FSSpecFileLister(prefix_uri)
-        dataset = torchdata.datapipes.iter.FSSpecFileOpener(lister, mode="rb")
-        if num_workers > 0:
-            dataset = dataset.sharding_filter()
-        if sharding == DatasetSharding.TAR:
-            dataset = dataset.load_from_tar()
-        return dataset.map(load_sample)
+        return create_fsspec_dataset(sharding, prefix_uri, load_sample, num_workers)
+    elif kind == "mountpoint":
+        return create_mountpoint_dataset(sharding, prefix_uri, load_sample, num_workers)
     else:
         raise Exception(f"unknown dataset kind {kind}")
+
+
+def create_s3_iterable_dataset(
+    sharding: Optional[DatasetSharding],
+    prefix_uri: str,
+    region: str,
+    load_sample,
+    num_workers: int,
+):
+    dataset = S3IterableDataset.from_prefix(prefix_uri, region=region)
+    dataset = torchdata.datapipes.iter.IterableWrapper(dataset)
+    if num_workers > 0:
+        dataset = dataset.sharding_filter()
+    if sharding == DatasetSharding.TAR:
+        dataset = dataset.map(tar_to_tuple)
+        dataset = dataset.load_from_tar()
+
+    return dataset.map(load_sample)
+
+
+def create_s3_map_dataset(
+    sharding: Optional[DatasetSharding], prefix_uri: str, region: str, load_sample
+):
+    if sharding:
+        raise ValueError("Sharding is not supported for s3mapdataset")
+    else:
+        dataset = S3MapDataset.from_prefix(
+            prefix_uri, region=region, transform=load_sample
+        )
+    return dataset
+
+
+def create_mountpoint_dataset(
+    sharding: Optional[DatasetSharding], prefix_uri: str, load_sample, num_workers: int
+):
+    prefix_uri = make_mountpoint(prefix_uri=prefix_uri)
+    # TODO: compare the performance of using torchdata file APIs and use the more performant option.
+    return create_fsspec_dataset(sharding, prefix_uri, load_sample, num_workers)
+
+
+def create_fsspec_dataset(
+    sharding: Optional[DatasetSharding],
+    prefix_uri: str,
+    load_sample: object,
+    num_workers: int,
+):
+    lister = torchdata.datapipes.iter.FSSpecFileLister(prefix_uri)
+    dataset = torchdata.datapipes.iter.FSSpecFileOpener(lister, mode="rb")
+    if num_workers > 0:
+        dataset = dataset.sharding_filter()
+    if sharding == DatasetSharding.TAR:
+        dataset = dataset.load_from_tar()
+
+    return dataset.map(load_sample)
 
 
 def make_dataloader(dataset: Dataset, num_workers: int, batch_size: int):


### PR DESCRIPTION
## Description
Adds support for running benchmarks against mountpoints-backed datasets. The feature relies on the `mount-s3` binary being installed and relies on the `FSSpecFileLister` and `FSSpecFileOpener` APIs exposed by torchdata to interact with the filesystem. A reference configuration `dataloader/mountpoint.yaml` has already been created that can be used in experiments. 

Note: This feature mounts all the objects under an s3 prefix at a temporary path on the filesystem, and also manages the clean up of the same via a signal handler that is invoked when the process terminates.

## Testing
Locally tested a sample scenario by running:
```
AWS_PROFILE=<PROFILE-NAME> ./venv/bin/s3torch-benchmark -cd conf -m -cn dataloading dataset.prefix_uri=<S3-PREFIX> dataloader=mountpoint dataset.region=<AWS-REGION>
```

```
2024-02-26 13:12:23,150][HYDRA] Launching 4 jobs locally
[2024-02-26 13:12:23,150][HYDRA] 	#0 : dataloader=mountpoint dataloader.num_workers=2 <redacted>
bucket swift-benchmark-dataset is mounted at /tmp/s3dataset_845qhz65
mountpoint trained entitlement in 33.7384s with 2.9640 samples per second
Resource usage of the workload was as follows:
{'cpu_util': 11.367466266866565, 'cpu_mem': 37.06821589205397, 'gpu_util': 0.0, 'gpu_mem': 0.0}
[2024-02-26 13:13:02,394][HYDRA] 	#1 : dataloader=mountpoint dataloader.num_workers=4 <redacted>
bucket swift-benchmark-dataset is mounted at /tmp/s3dataset_j464lkfh
mountpoint trained entitlement in 20.6110s with 4.8518 samples per second
Resource usage of the workload was as follows:
{'cpu_util': 15.406617647058823, 'cpu_mem': 37.098039215686285, 'gpu_util': 0.0, 'gpu_mem': 0.0}
[2024-02-26 13:13:24,478][HYDRA] 	#2 : dataloader=mountpoint dataloader.num_workers=8 <redacted>
bucket swift-benchmark-dataset is mounted at /tmp/s3dataset_bcwbo7h9
mountpoint trained entitlement in 18.9471s with 5.2779 samples per second
Resource usage of the workload was as follows:
{'cpu_util': 18.729066666666665, 'cpu_mem': 37.28906666666666, 'gpu_util': 0.0, 'gpu_mem': 0.0}
[2024-02-26 13:13:44,917][HYDRA] 	#3 : dataloader=mountpoint dataloader.num_workers=16 <redacted>
bucket swift-benchmark-dataset is mounted at /tmp/s3dataset_4lxrb1f4
/home/ANT.AMAZON.COM/vgd/w/s3-connector-for-pytorch/s3torchbenchmarking/venv/lib/python3.8/site-packages/torch/utils/data/dataloader.py:558: UserWarning: This DataLoader will create 16 worker processes in total. Our suggested max number of worker in current system is 8, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.
  warnings.warn(_create_warning_msg(
mountpoint trained entitlement in 20.0413s with 4.9897 samples per second
Resource usage of the workload was as follows:
{'cpu_util': 23.0896725440806, 'cpu_mem': 37.688161209068014, 'gpu_util': 0.0, 'gpu_mem': 0.0}

```

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
