### PR TITLE
Add strict support for mypy

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -105,8 +105,8 @@ jobs:
           src: "."
       - name: Typecheck with mypy
         run: |
-          mypy s3torchconnector/src
-          mypy s3torchconnectorclient/python/src
+          mypy --strict s3torchconnector/src
+          mypy --strict s3torchconnectorclient/python/src
 
   dependencies:
     name: Python dependencies checks

--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -70,8 +70,8 @@ For Python code changes, run
 black --verbose .
 flake8 s3torchconnector/ --count --select=E9,F63,F7,F82 --show-source --statistics
 flake8 s3torchconnectorclient/python --count --select=E9,F63,F7,F82 --show-source --statistics
-mypy s3torchconnector/src
-mypy s3torchconnectorclient/python/src
+mypy --strict s3torchconnector/src
+mypy --strict s3torchconnectorclient/python/src
 ```
  to lint.
 

--- a/s3torchconnector/src/s3torchconnector/_s3_bucket_iterable.py
+++ b/s3torchconnector/src/s3torchconnector/_s3_bucket_iterable.py
@@ -1,9 +1,11 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
+from __future__ import annotations
+
 
 from functools import partial
 from itertools import chain
-from typing import Iterator, List
+from typing import Iterator, Dict, Any
 
 from s3torchconnectorclient._mountpoint_s3_client import (
     ObjectInfo,
@@ -43,13 +45,13 @@ class _PickleableListObjectStream:
         self._client = client
         self._list_stream = iter(client.list_objects(bucket, prefix))
 
-    def __iter__(self):
+    def __iter__(self) -> _PickleableListObjectStream:
         return self
 
     def __next__(self) -> ListObjectResult:
         return next(self._list_stream)
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, Any]:
         return {
             "client": self._client,
             "bucket": self._list_stream.bucket,
@@ -60,7 +62,7 @@ class _PickleableListObjectStream:
             "complete": self._list_stream.complete,
         }
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         self._client = state["client"]
         self._list_stream = ListObjectStream._from_state(**state)
 

--- a/s3torchconnector/src/s3torchconnector/_user_agent.py
+++ b/s3torchconnector/src/s3torchconnector/_user_agent.py
@@ -15,7 +15,7 @@ class UserAgent:
         self._comments = comments or []
 
     @property
-    def prefix(self):
+    def prefix(self) -> str:
         comments_str = "; ".join(filter(None, self._comments))
         if comments_str:
             return f"{self._user_agent_prefix} ({comments_str})"

--- a/s3torchconnector/src/s3torchconnector/s3reader.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader.py
@@ -1,15 +1,16 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
+from __future__ import annotations
 
 import io
 from functools import cached_property
 from io import SEEK_CUR, SEEK_END, SEEK_SET
-from typing import Callable, Optional, Iterable, Iterator
+from typing import Callable, Optional, IO, Iterator, List, Any, Iterable
 
 from s3torchconnectorclient._mountpoint_s3_client import ObjectInfo, GetObjectStream
 
 
-class S3Reader(io.BufferedIOBase):
+class S3Reader(io.BufferedIOBase, IO[bytes]):
     """A read-only, file like representation of a single object stored in S3."""
 
     def __init__(
@@ -32,15 +33,15 @@ class S3Reader(io.BufferedIOBase):
         self._position = 0
 
     @property
-    def bucket(self):
+    def bucket(self) -> str:
         return self._bucket
 
     @property
-    def key(self):
+    def key(self) -> str:
         return self._key
 
     @cached_property
-    def _object_info(self):
+    def _object_info(self) -> ObjectInfo:
         return self._get_object_info()
 
     def prefetch(self) -> None:
@@ -187,3 +188,12 @@ class S3Reader(io.BufferedIOBase):
             bool: Return whether object was opened for writing.
         """
         return False
+
+    def write(self, data: Any) -> int:
+        raise OSError("Not implemented")
+
+    def writelines(self, data: Iterable[Any]) -> None:
+        raise OSError("Not implemented")
+
+    def __enter__(self) -> S3Reader:
+        return self

--- a/s3torchconnector/src/s3torchconnector/s3writer.py
+++ b/s3torchconnector/src/s3torchconnector/s3writer.py
@@ -1,25 +1,32 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
+from __future__ import annotations
 
 import io
-from typing import Union
+from types import TracebackType
+from typing import Union, IO, Iterable, Optional
 
 from s3torchconnectorclient._mountpoint_s3_client import PutObjectStream
 
 
-class S3Writer(io.BufferedIOBase):
+class S3Writer(io.BufferedIOBase, IO[bytes]):
     """A write-only, file like representation of a single object stored in S3."""
 
     def __init__(self, stream: PutObjectStream):
         self.stream = stream
 
-    def __enter__(self):
+    def __enter__(self) -> S3Writer:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         self.close()
 
-    def write(
+    def write(  # type: ignore
         self,
         # Ignoring the type for this as we don't currently support the Buffer protocol
         data: Union[bytes, memoryview],  # type: ignore
@@ -40,7 +47,15 @@ class S3Writer(io.BufferedIOBase):
         self.stream.write(data)
         return len(data)
 
-    def close(self):
+    def writelines(  # type: ignore
+        self,
+        # Ignoring the type for this as we don't currently support the Buffer protocol
+        data: Iterable[bytes | memoryview],  # type: ignore
+    ) -> None:
+        for line in data:
+            self.write(line)
+
+    def close(self) -> None:
         """Close write-stream to S3. Ensures all bytes are written successfully.
 
         Raises:
@@ -48,7 +63,7 @@ class S3Writer(io.BufferedIOBase):
         """
         self.stream.close()
 
-    def flush(self):
+    def flush(self) -> None:
         """No-op"""
         pass
 

--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/__init__.py
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/__init__.py
@@ -2,6 +2,7 @@
 #  // SPDX-License-Identifier: BSD
 
 import copyreg
+from typing import Tuple, Type, Any
 
 from ._logger_patch import TRACE as LOG_TRACE
 from ._logger_patch import _install_trace_logging
@@ -10,7 +11,7 @@ from ._mountpoint_s3_client import S3Exception, __version__
 _install_trace_logging()
 
 
-def _s3exception_reduce(exc: S3Exception):
+def _s3exception_reduce(exc: S3Exception) -> Tuple[Type[S3Exception], Any]:
     return S3Exception, exc.args
 
 

--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/_logger_patch.py
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/_logger_patch.py
@@ -6,5 +6,5 @@ import logging
 TRACE = 5
 
 
-def _install_trace_logging():
+def _install_trace_logging() -> None:
     logging.addLevelName(TRACE, "TRACE")


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Adds strict type checking with mypy.

`S3MapDataset` and `S3IterableDataset` are now implemented as generics. This has no impact for customers not using type checking, but should improve IDE & mypy support.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

Changes the constructor for `S3MapDataset` and `S3IterableDataset`. These constructors are not public, so it's OK to change.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

`mypy --strict s3torchconnector/src && mypy --strict s3torchconnectorclient/python/src` passes

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
