### PR TITLE
Move model's object to a correct device

### DIFF
--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -102,7 +102,7 @@ class ViT(ModelInterface):
     def model(self):
         return ViTForImageClassification.from_pretrained(
             "google/vit-base-patch16-224-in21k", num_labels=self.num_labels
-        )
+        ).to(self.device)
 
     @cached_property
     def transform(self):


### PR DESCRIPTION
## Description
There are discrepancy in where training data and model are located. When [train_batch](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/s3torchbenchmarking/src/s3torchbenchmarking/models.py#L139) function of  `ViT` class is called, the input parameters such as `data` and `target` are moved to available device, when `model` is stayed on the default device. To prevent such discrepancy the `model` is moved to the same device as `data` and `target`.
That problem was reported in https://github.com/awslabs/s3-connector-for-pytorch/issues/166 issue.

## Testing
Manually tested on instances with and without GPU (g5.8xlarge and c6a.4xlarge)

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
