### PR TITLE
Upgrade to mountpoint-s3-client-0.8.0 and update logging 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### New features
+
+### Breaking changes
+* Separate completely Rust logs and Python logs. Logs from Rust components, used for debugging purposes 
+are configured through the following environment variables: S3_TORCH_CONNECTOR_DEBUG_LOGS, 
+S3_TORCH_CONNECTOR_LOGS_DIR_PATH.
+
 ## v1.2.0 (March 13, 2024)
 
 ### New features
@@ -10,6 +19,7 @@
 
 ### Breaking changes
 * No breaking changes.
+
 
 ## v1.1.4 (February 26, 2024)
 
@@ -37,7 +47,6 @@
 * No breaking changes.
 
 
-
 ## v1.1.2 (January 19, 2024)
 
 ### New features
@@ -46,7 +55,6 @@
 
 ### Breaking changes
 * No breaking changes.
-
 
 
 ## v1.1.1 (December 11, 2023)
@@ -69,12 +77,11 @@
 * No breaking changes.
 
 
-
 ## v1.0.0 (November 22, 2023)
 * The Amazon S3 Connector for PyTorch delivers high throughput for PyTorch training jobs that access and store data in Amazon S3.
 
 ### New features
-* S3IterableDataset and S3MapDataset, which allow building either an iterable-style or map-style dataset, using your S3 
+* S3IterableDataset and S3MapDataset, which allow building either an iterable-style or map-style dataset, using your S3
 stored data, by specifying an S3 URI (a bucket and optional prefix) and the region the bucket is in.
 * Support for multiprocess data loading for the above datasets.
 * S3Checkpoint, an interface for saving and loading model checkpoints directly to and from an S3 bucket.

--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -92,3 +92,49 @@ Fill in the path of the Python executable in your virtual environment (`venv/bin
 as the program argument.
 Then put a breakpoint in the Rust/C code and try running it.
 
+#### Enabling Debug Logging
+The [Python logger](https://docs.python.org/3/library/logging.html) handles logging messages from the Python-side 
+of our implementation.
+For debug purposes, you can also enable the logs for our Rust components, which are off by default. 
+These are handled by [tracing_subscriber](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/) and can be 
+configured through the following environment variables:
+- `S3_TORCH_CONNECTOR_DEBUG_LOGS` - Configured similarly to the
+[RUST_LOG](https://docs.rs/env_logger/latest/env_logger/#enabling-logging) variable for
+filtering logs from our Rust components. This includes finer granularity logs from 
+[AWS Common Runtime (CRT)](https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html).
+**Please note that the AWS CRT logs are very noisy. We recommend to filter them out by appending `"awscrt=off"` to
+your S3_TORCH_CONNECTOR_DEBUG_LOGS setup.**
+- `S3_TORCH_CONNECTOR_LOGS_DIR_PATH` - The path to a local directory where you have write permissions. 
+When configured, the logs from the Rust components will be appended to a file at this location. 
+This will result in a log file located at 
+`${S3_TORCH_CONNECTOR_LOGS_DIR_PATH}/s3torchconnectorclient.log.yyyy-MM-dd-HH`, rolled on an hourly basis. 
+The log messages of the latest run are appended to the end of the most recent log file.
+
+**Examples**
+- Configure INFO level logs to be written to STDOUT:
+```sh
+  export S3_TORCH_CONNECTOR_DEBUG_LOGS=info
+```
+
+- Enable TRACE level logs (most verbose) to be written at `/tmp/s3torchconnector-logs`:
+```sh
+  export S3_TORCH_CONNECTOR_DEBUG_LOGS=trace
+  export S3_TORCH_CONNECTOR_LOGS_DIR_PATH="/tmp/s3torchconnector-logs"
+```
+After running your script, you will find the logs under `/tmp/s3torchconnector-logs`.
+The file will include AWS CRT logs. 
+
+- Enable TRACE level logs with AWS CRT logs filtered out, written at `/tmp/s3torchconnector-logs`:
+```sh
+  export S3_TORCH_CONNECTOR_DEBUG_LOGS=trace,awscrt=off
+  export S3_TORCH_CONNECTOR_LOGS_DIR_PATH="/tmp/s3torchconnector-logs"
+```
+
+- Set up different levels for inner components:
+```sh
+  export S3_TORCH_CONNECTOR_DEBUG_LOGS=trace,mountpoint_s3_client=debug,awscrt=error
+```
+This will set the log level to TRACE by default, DEBUG for mountpoint-s3-client and ERROR for AWS CRT.
+
+For more examples please check the 
+[env_logger documentation](https://docs.rs/env_logger/latest/env_logger/#enabling-logging).

--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.8"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -31,13 +31,15 @@ checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 2.5.3",
+ "event-listener 5.2.0",
+ "event-listener-strategy 0.5.0",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -66,7 +68,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
- "event-listener-strategy",
+ "event-listener-strategy 0.4.0",
  "pin-project-lite",
 ]
 
@@ -290,15 +292,20 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -312,6 +319,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.2.0",
  "pin-project-lite",
 ]
 
@@ -625,24 +642,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.21.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
 dependencies = [
  "ahash",
- "metrics-macros",
  "portable-atomic",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -653,9 +658,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f4a6aa3c34c8327d4723f0fc80301e89a226b97f36fb80b65110b6a1df8ea6"
+checksum = "f590cf9c81d96c727d61edac60f03f781a62d3c766208af39eb0ee038c66be1a"
 dependencies = [
  "async-io",
  "async-lock",
@@ -670,6 +675,7 @@ dependencies = [
  "md-5",
  "metrics",
  "mountpoint-s3-crt",
+ "mountpoint-s3-crt-sys",
  "once_cell",
  "percent-encoding",
  "pin-project",
@@ -687,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bf9ef7a549496401d3009181504896c513b842ef285d51e0a1583dab1fcd35"
+checksum = "b66a617b42bd5216f78746ccd3a769aa6291ec82790c875b6faba8ef1d4a8acc"
 dependencies = [
  "async-channel",
  "futures",
@@ -703,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282f6f10de9d91ff31b45bc45aa37b101721eeddb1c7a80f011755a93d3055f3"
+checksum = "837d2772731bfe53bf43999214ef5897b22a62f6dc1a67c0ab679ff2a47a765c"
 dependencies = [
  "bindgen",
  "cc",
@@ -1471,14 +1477,15 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -19,8 +19,8 @@ built = "0.7"
 pyo3 = { version = "0.19.2" }
 pyo3-log = "0.8.3"
 futures = "0.3.28"
-mountpoint-s3-client = { version = "0.7.0", features = ["mock"] }
-mountpoint-s3-crt = "0.6.1"
+mountpoint-s3-client = { version = "0.8.0", features = ["mock"] }
+mountpoint-s3-crt = "0.6.2"
 log = "0.4.20"
 tracing = { version = "0.1.40", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"]}

--- a/s3torchconnectorclient/python/tst/integration/test_logging.py
+++ b/s3torchconnectorclient/python/tst/integration/test_logging.py
@@ -3,8 +3,11 @@
 import os.path
 import sys
 import tempfile
+from typing import List
 
 import pytest
+
+from conftest import BucketPrefixFixture
 
 PYTHON_TEST_CODE = """
 import logging
@@ -13,10 +16,13 @@ import sys
 
 s3_uri = sys.argv[1]
 region = sys.argv[2]
-os.environ["ENABLE_CRT_LOGS"] = sys.argv[3]
+debug_logs_config = sys.argv[3]
 logs_dir_path = sys.argv[4]
+
+if debug_logs_config != "":
+    os.environ["S3_TORCH_CONNECTOR_DEBUG_LOGS"] = debug_logs_config
 if logs_dir_path != "":
-    os.environ["CRT_LOGS_DIR_PATH"] = logs_dir_path
+    os.environ["S3_TORCH_CONNECTOR_LOGS_DIR_PATH"] = logs_dir_path
 
 from s3torchconnector import S3MapDataset
 
@@ -35,7 +41,7 @@ import subprocess
 
 
 @pytest.mark.parametrize(
-    "log_level, should_contain, should_not_contain",
+    "debug_logs_config, should_contain, should_not_contain",
     [
         (
             "info",
@@ -68,35 +74,107 @@ import subprocess
         ("OFF", ["INFO s3torchconnector.s3map_dataset"], ["awscrt"]),
     ],
 )
-def test_logging_valid(log_level, should_contain, should_not_contain, image_directory):
-    out, err = _start_subprocess(log_level, image_directory)
+def test_crt_logging(
+    debug_logs_config: str,
+    should_contain: List[str],
+    should_not_contain: List[str],
+    image_directory: BucketPrefixFixture,
+):
+    out, err = _start_subprocess(image_directory, debug_logs_config=debug_logs_config)
     assert err == ""
     assert all(s in out for s in should_contain)
     assert all(s not in out for s in should_not_contain)
 
 
-def test_logging_to_file(image_directory):
+def test_default_logging_env_filters_unset(image_directory: BucketPrefixFixture):
+    out, err = _start_subprocess(image_directory)
+    # Standard output contains Python output
+    assert err == ""
+    assert "INFO s3torchconnector.s3map_dataset" in out
+    assert "awscrt::" not in out
+
+
+def test_logging_to_file_env_filters_unset(image_directory: BucketPrefixFixture):
     with tempfile.TemporaryDirectory() as log_dir:
         print("Created temporary directory", log_dir)
-        out, err = _start_subprocess("INFO", image_directory, log_dir)
+        out, err = _start_subprocess(image_directory, logs_directory=log_dir)
         # Standard output contains Python output
         assert err == ""
         assert "INFO s3torchconnector.s3map_dataset" in out
         assert "awscrt" not in out
+        files = os.listdir(log_dir)
+        assert len(files) == 0
+
+
+@pytest.mark.parametrize(
+    "debug_logs_config, out_should_contain, out_should_not_contain, file_should_contain, file_should_not_contain",
+    [
+        (
+            "info",
+            ["INFO s3torchconnector.s3map_dataset"],
+            ["awscrt"],
+            ["INFO awscrt::", "INFO"],
+            ["INFO s3torchconnector.s3map_dataset", "DEBUG", "TRACE"],
+        ),
+        (
+            "debug,awscrt=off",
+            ["INFO s3torchconnector.s3map_dataset", "awscrt=off"],
+            ["awscrt::"],
+            ["DEBUG", "mountpoint_s3_client"],
+            ["awscrt::", "INFO s3torchconnector.s3map_dataset", "TRACE"],
+        ),
+        (
+            "debug",
+            ["INFO s3torchconnector.s3map_dataset"],
+            ["awscrt"],
+            ["DEBUG", "mountpoint_s3_client", "DEBUG awscrt::", "INFO awscrt::"],
+            ["INFO s3torchconnector.s3map_dataset", "TRACE awscrt"],
+        ),
+    ],
+)
+def test_logging_to_file(
+    debug_logs_config: str,
+    out_should_contain: List[str],
+    out_should_not_contain: List[str],
+    file_should_contain: List[str],
+    file_should_not_contain: List[str],
+    image_directory: BucketPrefixFixture,
+):
+    with tempfile.TemporaryDirectory() as log_dir:
+        print("Created temporary directory", log_dir)
+        out, err = _start_subprocess(
+            image_directory,
+            debug_logs_config=debug_logs_config,
+            logs_directory=log_dir,
+        )
+        # Standard output contains Python output
+        assert err == ""
+        assert all(s in out for s in out_should_contain)
+        assert all(s not in out for s in out_should_not_contain)
         files = os.listdir(log_dir)
         assert len(files) == 1
         log_file = os.path.join(log_dir, files[0])
         assert os.path.isfile(log_file)
         with open(log_file) as f:
             file_content = f.read()
-            assert all(s in file_content for s in ["awscrt", "INFO"])
-            assert all(
-                s not in file_content
-                for s in ["INFO s3torchconnector.s3map_dataset", "DEBUG", "TRACE"]
-            )
+            assert all(s in file_content for s in file_should_contain)
+            assert all(s not in file_content for s in file_should_not_contain)
 
 
-def _start_subprocess(log_level, image_directory, logs_directory=""):
+def test_invalid_logging(image_directory):
+    out, err = _start_subprocess(image_directory, debug_logs_config="invalid123.&/?")
+    assert (
+        "s3torchconnectorclient._mountpoint_s3_client.S3Exception: invalid filter directive"
+        in err
+    )
+
+
+def _start_subprocess(
+    image_directory: BucketPrefixFixture,
+    *,
+    debug_logs_config: str = "",
+    logs_directory: str = "",
+):
     process = subprocess.Popen(
         [
             sys.executable,
@@ -104,7 +182,7 @@ def _start_subprocess(log_level, image_directory, logs_directory=""):
             PYTHON_TEST_CODE,
             image_directory.s3_uri,
             image_directory.region,
-            log_level,
+            debug_logs_config,
             logs_directory,
         ],
         stdout=subprocess.PIPE,

--- a/s3torchconnectorclient/python/tst/unit/test_mountpoint_s3_client.py
+++ b/s3torchconnectorclient/python/tst/unit/test_mountpoint_s3_client.py
@@ -4,9 +4,9 @@
 import logging
 import pickle
 import pytest
-from typing import Set
+from typing import Set, Optional
 
-from s3torchconnectorclient import LOG_TRACE, __version__
+from s3torchconnectorclient import __version__
 from s3torchconnectorclient._mountpoint_s3_client import (
     S3Exception,
     GetObjectStream,
@@ -19,7 +19,6 @@ from s3torchconnectorclient._mountpoint_s3_client import (
 logging.basicConfig(
     format="%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
 )
-logging.getLogger().setLevel(LOG_TRACE)
 
 
 REGION = "us-east-1"
@@ -126,7 +125,7 @@ def test_get_object_throws_stop_iteration():
         (set()),
     ],
 )
-def test_list_objects(expected_keys):
+def test_list_objects(expected_keys: Set[str]):
     mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
     for key in expected_keys:
         mock_client.add_object(key, b"")
@@ -284,7 +283,9 @@ def test_mountpoint_client_pickles():
         ("https://us-east-1.amazonaws.com", "https://us-east-1.amazonaws.com"),
     ],
 )
-def test_mountpoint_client_creation_with_region_and_endpoint(endpoint, expected):
+def test_mountpoint_client_creation_with_region_and_endpoint(
+    endpoint: Optional[str], expected: Optional[str]
+):
     client = MountpointS3Client(region=REGION, endpoint=endpoint)
     assert isinstance(client, MountpointS3Client)
     assert client.endpoint == expected


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

mountpoint-s3-client-0.8.0 contains changes incompatible with the logging setup.
Given the previous issues we had with this, we are separating these as follows: 
- Logging in the main Python component remains handled by Python logger.
- Logging in Rust components is handled by tracing_subscriber, set up through S3_TORCH_CONNECTOR_DEBUG_LOGS and S3_TORCH_CONNECTOR_LOGS_DIR_PATH environment variables. 

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

### Enabling Debug Logging
The [Python logger](https://docs.python.org/3/library/logging.html) handles logging messages from the Python-side of our implementation. For debug purposes, you can also enable the logs for our Rust components, which are off by default. These are handled by [tracing_subscriber](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/) and can be 
configured through the following environment variables:
- `S3_TORCH_CONNECTOR_DEBUG_LOGS` - Configured similarly to the [RUST_LOG](https://docs.rs/env_logger/latest/env_logger/#enabling-logging) variable for filtering logs from our Rust components. This includes finer granularity logs from [AWS Common Runtime (CRT)](https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html). **Please note that the AWS CRT logs are very noisy. We recommend to filter them out by appending `"awscrt=off"` to your S3_TORCH_CONNECTOR_DEBUG_LOGS setup.**
- `S3_TORCH_CONNECTOR_LOGS_DIR_PATH` - The path to a local directory where you have write permissions. When configured, the logs from the Rust components will be appended to a file at this location. This will result in a log file located at `${S3_TORCH_CONNECTOR_LOGS_DIR_PATH}/s3torchconnectorclient.log.yyyy-MM-dd-HH`, rolled on an hourly basis. The log messages of the latest run are appended to the end of the most recent log file.

**Examples**
- Configure INFO level logs to be written to STDOUT:
```sh
  export S3_TORCH_CONNECTOR_DEBUG_LOGS=info
```

- Enable TRACE level logs (most verbose) to be written at `/tmp/s3torchconnector-logs`:
```sh
  export S3_TORCH_CONNECTOR_DEBUG_LOGS=trace
  export S3_TORCH_CONNECTOR_LOGS_DIR_PATH="/tmp/s3torchconnector-logs"
```
After running your script, you will find the logs under `/tmp/s3torchconnector-logs`.
The file will include AWS CRT logs. 

- Enable TRACE level logs with AWS CRT logs filtered out, written at `/tmp/s3torchconnector-logs`:
```sh
  export S3_TORCH_CONNECTOR_DEBUG_LOGS=trace,awscrt=off
  export S3_TORCH_CONNECTOR_LOGS_DIR_PATH="/tmp/s3torchconnector-logs"
```

- Set up different levels for inner components:
```sh
  export S3_TORCH_CONNECTOR_DEBUG_LOGS=trace,mountpoint_s3_client=debug,awscrt=error
```
This will set the log level to TRACE by default, DEBUG for mountpoint-s3-client and ERROR for AWS CRT.

For more examples please check the 
[env_logger documentation](https://docs.rs/env_logger/latest/env_logger/#enabling-logging).

- [X] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->
- Unit & integration tests
--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
