### PR TITLE
Tell pytest to use current/root folder as working directory

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -54,11 +54,11 @@ jobs:
           python -m pip install -e "s3torchbenchmarking[test]"
 
       - name: s3torchconnectorclient unit tests
-        run: pytest s3torchconnectorclient/python/tst/unit --hypothesis-profile ci --hypothesis-show-statistics
+        run: pytest s3torchconnectorclient/python/tst/unit --hypothesis-profile ci --hypothesis-show-statistics -c ./
       - name: s3torchconnector unit tests
-        run: pytest s3torchconnector/tst/unit --ignore s3torchconnector/tst/unit/lightning --hypothesis-profile ci --hypothesis-show-statistics
+        run: pytest s3torchconnector/tst/unit --ignore s3torchconnector/tst/unit/lightning --hypothesis-profile ci --hypothesis-show-statistics -c ./
       - name: s3torchbenchmarking unit tests
-        run: pytest s3torchbenchmarking/tst --hypothesis-profile ci --hypothesis-show-statistics
+        run: pytest s3torchbenchmarking/tst --hypothesis-profile ci --hypothesis-show-statistics -c ./
 
   lint:
     name: Python lints


### PR DESCRIPTION
## Description
Pytest 8.1.1 starts to ignore `conftest.py` located in the root directory. That leads to error with loading `ci` profile for hypothesis. To prevent that issue, we will tell pytest to use current/root folder as working folder.

## Testing
Tested changes locally

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
