### PR TITLE
Allow wheel workflow to run on demand

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags: [ "v[0-9]+.[0-9]+.[0-9]+" ]
     branches: [ "dependabot/*", "main", "workflow/*" ]
+  workflow_dispatch:
 
 env:
   S3_REGION: ${{ vars.S3_REGION }}


### PR DESCRIPTION
## Description
Use [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) to allow running wheels workflow manually, when it is needed.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
