### PR TITLE
Fix wheels workflow for Lightning

### DIFF
--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -56,7 +56,7 @@ test-command = [
     "python -m pip install -e '{package}/../s3torchconnector[lightning]'",
     "pytest {package}/../s3torchconnector/tst/unit/lightning",
     "CI_STORAGE_CLASS='' CI_REGION=${S3_REGION} CI_BUCKET=${S3_BUCKET} CI_PREFIX=${S3_PREFIX} CI_CUSTOM_ENDPOINT_URL=${S3_CUSTOM_ENDPOINT_URL} pytest {package}/../s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py",
-    "CI_STORAGE_CLASS=EXPRESS_ONEZONE CI_REGION=${S3_EXPRESS_REGION} CI_BUCKET=${S3_EXPRESS_BUCKET} CI_PREFIX=${S3_PREFIX} CI_CUSTOM_ENDPOINT_URL='' pytest {package}/../s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py",
+    "AWS_DEFAULT_REGION=${S3_EXPRESS_REGION} CI_STORAGE_CLASS=EXPRESS_ONEZONE CI_REGION=${S3_EXPRESS_REGION} CI_BUCKET=${S3_EXPRESS_BUCKET} CI_PREFIX=${S3_PREFIX} CI_CUSTOM_ENDPOINT_URL='' pytest {package}/../s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py",
 ]
 environment-pass = [
     "AWS_ACCESS_KEY_ID",


### PR DESCRIPTION
Wheels build for feature/lightning-support is failing the compatibility tests with Lightning checkpoints for S3OZ, due to s3fs failing to find the bucket and trying to create a new one, action for which we do not grant permissions.

## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
A subset of integration tests for S3OZ are failing when building our binaries.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

We are running these tests as part of our [integration tests workflow](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/8254183011/job/22577732929) on the feature branch, and they are not failing there, but only on the wheels build workflow. After a deep dive in the output, I noticed that for S3OZ the region was incorrectly set in the environment where the wheels are built.

- Stack trace:
```
 _________________________ test_load_trained_checkpoint _________________________
  func = <bound method ClientCreator._create_api_method.<locals>._api_call of <aiobotocore.client.S3 object at 0x7f149ac56210>>
      async def _error_wrapper(func, *, args=(), kwargs=None, retries):
          if kwargs is None:
              kwargs = {}
          for i in range(retries):
              try:
  >               return await func(*args, **kwargs)
  ../venv/lib/python3.11/site-packages/s3fs/core.py:113: 
...
E           botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the CreateBucket operation: Access Denied
```
- Failing workflow [example](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/8256088080/job/22584122004).

- [ ] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->
- [Test workflow](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/8261630562/job/22599417580)
--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
