### PR TITLE
Collate multirun results into a single json file

### DIFF
--- a/s3torchbenchmarking/README.md
+++ b/s3torchbenchmarking/README.md
@@ -185,11 +185,17 @@ Finally, once the dataset and other configuration modules have been defined, you
     # Example-2:
     $ s3torch-benchmark -cd conf -m -cn checkpointing 'dataset.prefix_uri=<S3-PREFIX>' 'dataset.region=eu-west-2'
 
+    # Example with suppressed warnings (*nix only) - makes logs less noisy.
+    $ s3torch-benchmark -cd conf -m -cn checkpointing 'dataset.prefix_uri=<S3-PREFIX>' 'dataset.region=eu-west-2' 2>/dev/null
+
 _Note: For overriding any other benchmark parameters,
 see [Hydra Overrides](https://hydra.cc/docs/advanced/override_grammar/basic/). You can also run `s3torch-benchmark --hydra-help` to learn more._
 
+
 Experiments will report total training time, number of training samples as well as host-level metrics like CPU
-Utilisation, GPU Utilisation (if available) etc.
+Utilisation, GPU Utilisation (if available) etc. The results for individual jobs will be written out to dedicated
+`result.json` files within their corresponding [output dirs](https://hydra.cc/docs/configure_hydra/intro/#hydraruntime).
+When using Multirun mode, a `collated_results.json` will be written out to the [common sweep dir](https://hydra.cc/docs/configure_hydra/intro/#hydrasweep). 
 
 ## Next Steps
 

--- a/s3torchbenchmarking/conf/checkpointing.yaml
+++ b/s3torchbenchmarking/conf/checkpointing.yaml
@@ -4,6 +4,8 @@ defaults:
   - dataset: unsharded_dataset
   - training: vit
   - checkpoint: ???
+  - /hydra/callbacks:
+    - collate_results
 
 
 hydra:

--- a/s3torchbenchmarking/conf/dataloading.yaml
+++ b/s3torchbenchmarking/conf/dataloading.yaml
@@ -4,6 +4,8 @@ defaults:
   - dataset: unsharded_dataset
   - training: entitlement
   - checkpoint: none
+  - /hydra/callbacks:
+    - collate_results
 
 hydra:
   mode: MULTIRUN

--- a/s3torchbenchmarking/conf/hydra/callbacks/collate_results.yaml
+++ b/s3torchbenchmarking/conf/hydra/callbacks/collate_results.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+hydra:
+  callbacks:
+    my_callback:
+      _target_: s3torchbenchmarking.ResultCollatingCallback

--- a/s3torchbenchmarking/conf/sharding.yaml
+++ b/s3torchbenchmarking/conf/sharding.yaml
@@ -4,7 +4,8 @@ defaults:
   - dataset: sharded_dataset
   - training: entitlement
   - checkpoint: none
-
+  - /hydra/callbacks:
+    - collate_results
 
 hydra:
   mode: MULTIRUN

--- a/s3torchbenchmarking/src/s3torchbenchmarking/__init__.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/__init__.py
@@ -1,0 +1,3 @@
+from .hydra_callbacks import ResultCollatingCallback
+
+__all__ = ["ResultCollatingCallback"]

--- a/s3torchbenchmarking/src/s3torchbenchmarking/hydra_callbacks.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/hydra_callbacks.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+from typing import Any, List, Optional
+
+from hydra.core.utils import JobReturn
+from hydra.experimental.callback import Callback
+from omegaconf import DictConfig, OmegaConf
+
+
+class ResultCollatingCallback(Callback):
+    def __init__(self):
+        self.multirun_dir = Optional[Path]
+        self.job_returns: List[JobReturn] = []
+
+    def on_job_end(
+        self, config: DictConfig, job_return: JobReturn, **kwargs: Any
+    ) -> None:
+        """
+        Runtime variables like the output directory are not available when `on_multirun_end` is called, but they
+        are available when this method is called. So we collect them here and refer to this common state later.
+        """
+        self.job_returns.append(job_return)
+        self.multirun_dir = Path(
+            job_return.hydra_cfg["hydra"]["runtime"]["output_dir"]
+        ).parent
+
+    def on_multirun_end(self, config: DictConfig, **kwargs: Any) -> None:
+        collated_results = self._collate_results()
+        results_path = self._write_results(collated_results)
+        print(f"Collated results written to: {results_path}")
+
+    def _collate_results(self) -> List:
+        collated_results = []
+        for job_return in self.job_returns:
+            job_output_dir = Path(
+                job_return.hydra_cfg["hydra"]["runtime"]["output_dir"]
+            )
+            job_result_path = job_output_dir / "result.json"
+            with open(job_result_path) as infile:
+                item = {
+                    "job_id": job_return.hydra_cfg["hydra"]["job"]["id"],
+                    "cfg": OmegaConf.to_container(job_return.cfg),
+                    "result": json.load(infile),
+                }
+                collated_results.append(item)
+        return collated_results
+
+    def _write_results(self, collated_results: List) -> Path:
+        results_path = self.multirun_dir / "collated_results.json"
+        with open(results_path, "w") as outfile:
+            json.dump(collated_results, outfile)
+
+        return results_path


### PR DESCRIPTION
## Description
This change will make the benchmark results machine parseable and allow for future extensions like plotting, storage and regression testing.


## Additional context
Results of individual jobs are written out to dedicated `result.json` files. On Multirun end, all results are collated into a `collated_results.json`.

Other minor changes include:
- Introduce a bespoke Distribution type to accumulate scalar values and provide summarized stats on the distribution.
- Use the Distribution type in resource monitor and for checkpoint results.
-  Move resource monitoring logic into abstract `model.train` method.


[x] I have updated the CHANGELOG or README if appropriate

## Related items
- https://github.com/awslabs/s3-connector-for-pytorch/issues/175

## Testing

````
$ AWS_PROFILE=s3-open-source ./venv/bin/s3torch-benchmark -cd s3torchbenchmarking/conf -m -cn dataloading dataset=100_512x512_images_4Mb_shards

...
benchmark results written to: /home/ANT.AMAZON.COM/vgd/w/vgd-swift/multirun/2024-03-14/20-29-13/7/result.json
Multirun results written to: /home/ANT.AMAZON.COM/vgd/w/vgd-swift/multirun/2024-03-14/20-29-13/collated_results.json

$ jq . < /home/ANT.AMAZON.COM/vgd/w/vgd-swift/multirun/2024-03-14/20-20-48/collated_results.json
[
  {
    "job_id": "0",
    "cfg": {
      "dataloader": {
        "kind": "s3iterabledataset",
        "batch_size": 128,
        "num_workers": 2
      },
      "dataset": {
        "prefix_uri": "s3://swift-benchmark-dataset/4_512x512_images/",
        "region": "eu-west-2",
        "sharding": null
      },
      "training": {
        "model": "entitlement",
        "max_epochs": 1
      },
      "checkpoint": {
        "save_one_in": 0
      }
    },
    "result": {
      "volume": 8,
      "elapsed_time": 2.1905791710014455,
      "throughput": 3.652002222016344,
      "utilization": {
        "cpu_util": {
          "n": 44,
          "mean": 12.7341,
          "min": 0,
          "p50": 9.65,
          "p75": 15.325,
          "p90": 31.97,
          "max": 52.5
        },
        "cpu_mem": {
          "n": 44,
          "mean": 41.2727,
          "min": 41.1,
          "p50": 41.25,
          "p75": 41.4,
          "p90": 41.4,
          "max": 41.5
        }
      }
    }
  },
  {
    "job_id": "1",
    "cfg": {
      "dataloader": {
        "kind": "s3iterabledataset",
        "batch_size": 128,
        "num_workers": 4
      },
      "dataset": {
        "prefix_uri": "s3://swift-benchmark-dataset/4_512x512_images/",
        "region": "eu-west-2",
        "sharding": null
      },
      "training": {
        "model": "entitlement",
        "max_epochs": 1
      },
      "checkpoint": {
        "save_one_in": 0
      }
    },
    "result": {
      "volume": 8,
      "elapsed_time": 1.5441310459864326,
      "throughput": 5.180907424142479,
      "utilization": {
        "cpu_util": {
          "n": 31,
          "mean": 21.071,
          "min": 0,
          "p50": 10,
          "p75": 18.25,
          "p90": 59.5,
          "max": 90.5
        },
        "cpu_mem": {
          "n": 31,
          "mean": 41.229,
          "min": 41.1,
          "p50": 41.2,
          "p75": 41.2,
          "p90": 41.4,
          "max": 41.5
        }
      }
    }
  }
]

```

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
