### PR TITLE
Expose S3ClientConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### New features
+* Expose `throughput_target_gbps` and `part_size` configurations of the inner S3 client.
+
 ## v1.2.1 (March 14, 2024)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### New features
-* Expose `throughput_target_gbps` and `part_size` configurations of the inner S3 client.
+* Expose a new class, S3ClientConfig, with `throughput_target_gbps` and `part_size` parameters of the inner S3 client.
 
 ## v1.2.1 (March 14, 2024)
 

--- a/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
@@ -75,7 +75,6 @@ class ExperimentResult:
 
 
 class ExperimentResultJsonEncoder(JSONEncoder):
-
     def default(self, o: Any) -> Any:
         if isinstance(o, ExperimentResult):
             o: ExperimentResult = o

--- a/s3torchconnector/src/s3torchconnector/__init__.py
+++ b/s3torchconnector/src/s3torchconnector/__init__.py
@@ -11,6 +11,7 @@ from .s3iterable_dataset import S3IterableDataset
 from .s3map_dataset import S3MapDataset
 from .s3checkpoint import S3Checkpoint
 from ._version import __version__
+from ._s3client import S3ClientConfig
 
 __all__ = [
     "S3IterableDataset",
@@ -19,5 +20,6 @@ __all__ = [
     "S3Reader",
     "S3Writer",
     "S3Exception",
+    "S3ClientConfig",
     "__version__",
 ]

--- a/s3torchconnector/src/s3torchconnector/_s3client/__init__.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/__init__.py
@@ -1,7 +1,12 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 
+from .s3client_config import S3ClientConfig
 from ._s3client import S3Client
 from ._mock_s3client import MockS3Client
 
-__all__ = ["S3Client", "MockS3Client"]
+__all__ = [
+    "S3ClientConfig",
+    "S3Client",
+    "MockS3Client",
+]

--- a/s3torchconnector/src/s3torchconnector/_s3client/_mock_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_mock_s3client.py
@@ -10,6 +10,7 @@ from s3torchconnectorclient._mountpoint_s3_client import (
 
 from . import S3Client
 from .._user_agent import UserAgent
+from .s3client_config import S3ClientConfig
 
 """
 _mock_s3client.py
@@ -22,14 +23,19 @@ class MockS3Client(S3Client):
         self,
         region: str,
         bucket: str,
-        part_size: int = 8 * 1024 * 1024,
         user_agent: Optional[UserAgent] = None,
+        s3client_config: Optional[S3ClientConfig] = None,
     ):
-        super().__init__(region, user_agent=user_agent)
+        super().__init__(
+            region,
+            user_agent=user_agent,
+            s3client_config=s3client_config,
+        )
         self._mock_client = MockMountpointS3Client(
             region,
             bucket,
-            part_size=part_size,
+            throughput_target_gbps=self.s3client_config.throughput_target_gbps,
+            part_size=self.s3client_config.part_size,
             user_agent_prefix=self.user_agent_prefix,
         )
 

--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -7,6 +7,7 @@ from functools import partial
 from typing import Optional, Any
 
 from s3torchconnector import S3Reader, S3Writer
+from .s3client_config import S3ClientConfig
 
 from s3torchconnectorclient._mountpoint_s3_client import (
     MountpointS3Client,
@@ -35,8 +36,10 @@ class S3Client:
     def __init__(
         self,
         region: str,
+        *,
         endpoint: Optional[str] = None,
         user_agent: Optional[UserAgent] = None,
+        s3client_config: Optional[S3ClientConfig] = None,
     ):
         self._region = region
         self._endpoint = endpoint
@@ -44,6 +47,7 @@ class S3Client:
         self._client_pid: Optional[int] = None
         user_agent = user_agent or UserAgent()
         self._user_agent_prefix = user_agent.prefix
+        self._s3client_config = s3client_config or S3ClientConfig()
 
     @property
     def _client(self) -> MountpointS3Client:
@@ -59,6 +63,10 @@ class S3Client:
         return self._region
 
     @property
+    def s3client_config(self) -> S3ClientConfig:
+        return self._s3client_config
+
+    @property
     def user_agent_prefix(self) -> str:
         return self._user_agent_prefix
 
@@ -67,6 +75,8 @@ class S3Client:
             region=self._region,
             endpoint=self._endpoint,
             user_agent_prefix=self._user_agent_prefix,
+            throughput_target_gbps=self._s3client_config.throughput_target_gbps,
+            part_size=self._s3client_config.part_size,
         )
 
     def get_object(

--- a/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
@@ -6,11 +6,9 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class S3ClientConfig:
     """A dataclass exposing configurable parameters for the S3 client.
-    Returns a config wrapper object.
 
     Args:
     throughput_target_gbps(float): Throughput target in Gigabits per second (Gbps) that we are trying to reach.
-        You can also use get_recommended_throughput_target_gbps() to get recommended value for your system.
         10.0 Gbps by default (may change in future).
     part_size(int): Size, in bytes, of parts that files will be downloaded or uploaded in.
         Note: for saving checkpoints, the inner client will adjust the part size to meet the service limits.

--- a/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
@@ -1,0 +1,23 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class S3ClientConfig:
+    """A dataclass exposing configurable parameters for the S3 client.
+    Returns a config wrapper object.
+
+    Args:
+    throughput_target_gbps(float): Throughput target in Gigabits per second (Gbps) that we are trying to reach.
+        You can also use get_recommended_throughput_target_gbps() to get recommended value for your system.
+        10.0 Gbps by default (may change in future).
+    part_size(int): Size, in bytes, of parts that files will be downloaded or uploaded in.
+        Note: for saving checkpoints, the inner client will adjust the part size to meet the service limits.
+        (max number of parts per upload is 10,000, minimum upload part size is 5 MiB).
+        Part size must have values between 5MiB and 5GiB.
+        8MB by default (may change in future).
+    """
+
+    throughput_target_gbps: float = 10.0
+    part_size: int = 8 * 1024 * 1024

--- a/s3torchconnector/src/s3torchconnector/lightning/s3_lightning_checkpoint.py
+++ b/s3torchconnector/src/s3torchconnector/lightning/s3_lightning_checkpoint.py
@@ -8,7 +8,7 @@ import torch
 
 from lightning.pytorch.plugins.io import CheckpointIO
 
-from .._s3client import S3Client
+from .._s3client import S3Client, S3ClientConfig
 from .._s3dataset_common import parse_s3_uri
 from .._user_agent import UserAgent
 
@@ -16,10 +16,18 @@ from .._user_agent import UserAgent
 class S3LightningCheckpoint(CheckpointIO):
     """A checkpoint manager for S3 using the :class:`CheckpointIO` interface."""
 
-    def __init__(self, region: str):
+    def __init__(
+        self,
+        region: str,
+        s3client_config: Optional[S3ClientConfig] = None,
+    ):
         self.region = region
         user_agent = UserAgent(["lightning", lightning.__version__])
-        self._client = S3Client(region, user_agent=user_agent)
+        self._client = S3Client(
+            region,
+            user_agent=user_agent,
+            s3client_config=s3client_config,
+        )
 
     def save_checkpoint(
         self,

--- a/s3torchconnector/src/s3torchconnector/s3checkpoint.py
+++ b/s3torchconnector/src/s3torchconnector/s3checkpoint.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 from ._s3dataset_common import parse_s3_uri
-from ._s3client import S3Client
+from ._s3client import S3Client, S3ClientConfig
 from . import S3Reader, S3Writer
 
 
@@ -17,10 +17,17 @@ class S3Checkpoint:
     torch.load, and torch.save.
     """
 
-    def __init__(self, region: str, endpoint: Optional[str] = None):
+    def __init__(
+        self,
+        region: str,
+        endpoint: Optional[str] = None,
+        s3client_config: Optional[S3ClientConfig] = None,
+    ):
         self.region = region
         self.endpoint = endpoint
-        self._client = S3Client(region, endpoint)
+        self._client = S3Client(
+            region, endpoint=endpoint, s3client_config=s3client_config
+        )
 
     def reader(self, s3_uri: str) -> S3Reader:
         """Creates an S3Reader from a given s3_uri.

--- a/s3torchconnector/src/s3torchconnector/s3reader.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader.py
@@ -4,7 +4,7 @@
 import io
 from functools import cached_property
 from io import SEEK_CUR, SEEK_END, SEEK_SET
-from typing import Callable, Optional, Iterable, Iterator
+from typing import Callable, Optional, Iterator
 
 from s3torchconnectorclient._mountpoint_s3_client import ObjectInfo, GetObjectStream
 

--- a/s3torchconnector/tst/unit/test_s3_client.py
+++ b/s3torchconnector/tst/unit/test_s3_client.py
@@ -4,12 +4,14 @@ import logging
 import pytest
 
 from hypothesis import given
-from hypothesis.strategies import lists, text
+from hypothesis.strategies import lists, text, integers, floats
 from unittest.mock import MagicMock
+
+from s3torchconnectorclient._mountpoint_s3_client import S3Exception
 
 from s3torchconnector._user_agent import UserAgent
 from s3torchconnector._version import __version__
-from s3torchconnector._s3client import S3Client, MockS3Client
+from s3torchconnector._s3client import S3Client, MockS3Client, S3ClientConfig
 
 TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key"
@@ -82,3 +84,34 @@ def test_user_agent_always_starts_with_package_version(comments):
     if comments_str:
         assert comments_str in s3_client.user_agent_prefix
         assert comments_str in s3_client._client.user_agent_prefix
+
+
+@given(
+    part_size=integers(min_value=5 * 1024, max_value=5 * 1024 * 1024),
+    throughput_target_gbps=floats(min_value=10.0, max_value=100.0),
+)
+def test_s3_client_custom_config(part_size: int, throughput_target_gbps: float):
+    # Part size must have values between 5MiB and 5GiB
+    part_size = part_size * 1024
+    s3_client = S3Client(
+        region=TEST_REGION,
+        s3client_config=S3ClientConfig(
+            part_size=part_size,
+            throughput_target_gbps=throughput_target_gbps,
+        ),
+    )
+    assert s3_client._client.part_size == part_size
+    assert abs(s3_client._client.throughput_target_gbps - throughput_target_gbps) < 1e-9
+
+
+def test_s3_client_invalid_part_size_config():
+    with pytest.raises(
+        S3Exception,
+        match="invalid configuration: part size must be at between 5MiB and 5GiB",
+    ):
+        s3_client = S3Client(
+            region=TEST_REGION,
+            s3client_config=S3ClientConfig(part_size=1),
+        )
+        # The client is lazily initialized
+        assert s3_client._client.part_size is not None

--- a/s3torchconnector/tst/unit/test_s3_client.py
+++ b/s3torchconnector/tst/unit/test_s3_client.py
@@ -3,7 +3,7 @@
 import logging
 import pytest
 
-from hypothesis import given
+from hypothesis import given, example
 from hypothesis.strategies import lists, text, integers, floats
 from unittest.mock import MagicMock
 
@@ -17,6 +17,10 @@ TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key"
 TEST_REGION = "us-east-1"
 S3_URI = f"s3://{TEST_BUCKET}/{TEST_KEY}"
+
+KiB = 1 << 10
+MiB = 1 << 20
+GiB = 1 << 30
 
 
 @pytest.fixture
@@ -87,12 +91,13 @@ def test_user_agent_always_starts_with_package_version(comments):
 
 
 @given(
-    part_size=integers(min_value=5 * 1024, max_value=5 * 1024 * 1024),
+    part_size=integers(min_value=5 * MiB, max_value=5 * GiB),
     throughput_target_gbps=floats(min_value=10.0, max_value=100.0),
 )
+@example(part_size=5 * MiB, throughput_target_gbps=10.0)
+@example(part_size=5 * GiB, throughput_target_gbps=15.0)
 def test_s3_client_custom_config(part_size: int, throughput_target_gbps: float):
     # Part size must have values between 5MiB and 5GiB
-    part_size = part_size * 1024
     s3_client = S3Client(
         region=TEST_REGION,
         s3client_config=S3ClientConfig(
@@ -101,17 +106,18 @@ def test_s3_client_custom_config(part_size: int, throughput_target_gbps: float):
         ),
     )
     assert s3_client._client.part_size == part_size
-    assert abs(s3_client._client.throughput_target_gbps - throughput_target_gbps) < 1e-9
+    assert s3_client._client.throughput_target_gbps == throughput_target_gbps
 
 
-def test_s3_client_invalid_part_size_config():
+@pytest.mark.parametrize("part_size", [1, 2 * KiB, 6 * GiB])
+def test_s3_client_invalid_part_size_config(part_size: int):
     with pytest.raises(
         S3Exception,
         match="invalid configuration: part size must be at between 5MiB and 5GiB",
     ):
         s3_client = S3Client(
             region=TEST_REGION,
-            s3client_config=S3ClientConfig(part_size=1),
+            s3client_config=S3ClientConfig(part_size=part_size),
         )
         # The client is lazily initialized
         assert s3_client._client.part_size is not None

--- a/s3torchconnector/tst/unit/test_s3_client.py
+++ b/s3torchconnector/tst/unit/test_s3_client.py
@@ -109,7 +109,16 @@ def test_s3_client_custom_config(part_size: int, throughput_target_gbps: float):
     assert s3_client._client.throughput_target_gbps == throughput_target_gbps
 
 
-@pytest.mark.parametrize("part_size", [1, 2 * KiB, 6 * GiB])
+@pytest.mark.parametrize(
+    "part_size",
+    [
+        1,
+        2 * KiB,
+        5 * MiB - 1,
+        5 * GiB + 1,
+        6 * GiB,
+    ],
+)
 def test_s3_client_invalid_part_size_config(part_size: int):
     with pytest.raises(
         S3Exception,
@@ -120,4 +129,4 @@ def test_s3_client_invalid_part_size_config(part_size: int):
             s3client_config=S3ClientConfig(part_size=part_size),
         )
         # The client is lazily initialized
-        assert s3_client._client.part_size is not None
+        assert s3_client._client.part_size == part_size

--- a/s3torchconnector/tst/unit/test_s3_client_config.py
+++ b/s3torchconnector/tst/unit/test_s3_client_config.py
@@ -1,0 +1,42 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+from hypothesis import given
+from hypothesis.strategies import integers, floats
+
+from s3torchconnector import S3ClientConfig
+
+
+def test_default():
+    config = S3ClientConfig()
+    assert config is not None
+    assert config.part_size == 8 * 1024 * 1024
+    assert abs(config.throughput_target_gbps - 10.0) < 1e-9
+
+
+@given(part_size=integers(min_value=1, max_value=1e12))
+def test_part_size_setup(part_size: int):
+    config = S3ClientConfig(part_size=part_size)
+    assert config is not None
+    assert config.part_size == part_size
+    assert abs(config.throughput_target_gbps - 10.0) < 1e-9
+
+
+@given(throughput_target_gbps=floats(min_value=1.0, max_value=100.0))
+def test_throughput_target_gbps_setup(throughput_target_gbps: float):
+    config = S3ClientConfig(throughput_target_gbps=throughput_target_gbps)
+    assert config is not None
+    assert config.part_size == 8 * 1024 * 1024
+    assert abs(config.throughput_target_gbps - throughput_target_gbps) < 1e-9
+
+
+@given(
+    part_size=integers(min_value=1, max_value=1e12),
+    throughput_target_gbps=floats(min_value=1.0, max_value=100.0),
+)
+def test_custom_setup(part_size: int, throughput_target_gbps: float):
+    config = S3ClientConfig(
+        part_size=part_size, throughput_target_gbps=throughput_target_gbps
+    )
+    assert config is not None
+    assert config.part_size == part_size
+    assert abs(config.throughput_target_gbps - throughput_target_gbps) < 1e-9

--- a/s3torchconnector/tst/unit/test_s3_client_config.py
+++ b/s3torchconnector/tst/unit/test_s3_client_config.py
@@ -1,42 +1,41 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
-from hypothesis import given
+from hypothesis import given, example
 from hypothesis.strategies import integers, floats
 
 from s3torchconnector import S3ClientConfig
+from .test_s3_client import MiB, GiB
 
 
 def test_default():
     config = S3ClientConfig()
-    assert config is not None
-    assert config.part_size == 8 * 1024 * 1024
-    assert abs(config.throughput_target_gbps - 10.0) < 1e-9
+    assert config.part_size == 8 * MiB
+    assert config.throughput_target_gbps == 10.0
 
 
-@given(part_size=integers(min_value=1, max_value=1e12))
+@given(part_size=integers(min_value=5 * MiB, max_value=5 * GiB))
 def test_part_size_setup(part_size: int):
     config = S3ClientConfig(part_size=part_size)
-    assert config is not None
     assert config.part_size == part_size
-    assert abs(config.throughput_target_gbps - 10.0) < 1e-9
+    assert config.throughput_target_gbps == 10.0
 
 
 @given(throughput_target_gbps=floats(min_value=1.0, max_value=100.0))
 def test_throughput_target_gbps_setup(throughput_target_gbps: float):
     config = S3ClientConfig(throughput_target_gbps=throughput_target_gbps)
-    assert config is not None
     assert config.part_size == 8 * 1024 * 1024
-    assert abs(config.throughput_target_gbps - throughput_target_gbps) < 1e-9
+    assert config.throughput_target_gbps == throughput_target_gbps
 
 
 @given(
-    part_size=integers(min_value=1, max_value=1e12),
+    part_size=integers(min_value=5 * MiB, max_value=5 * GiB),
     throughput_target_gbps=floats(min_value=1.0, max_value=100.0),
 )
+@example(part_size=5 * MiB, throughput_target_gbps=10.0)
+@example(part_size=5 * GiB, throughput_target_gbps=15.0)
 def test_custom_setup(part_size: int, throughput_target_gbps: float):
     config = S3ClientConfig(
         part_size=part_size, throughput_target_gbps=throughput_target_gbps
     )
-    assert config is not None
     assert config.part_size == part_size
-    assert abs(config.throughput_target_gbps - throughput_target_gbps) < 1e-9
+    assert config.throughput_target_gbps == throughput_target_gbps


### PR DESCRIPTION
## Description
We expose the following configuration flags with performance impact: `throughput_target_gbps` and `part_size`.

<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->
 - `throughput_target_gbps(float)`: Throughput target in Gigabits per second (Gbps) that we are trying to reach.
        10.0 Gbps by default (may change in future).
 - `part_size(int)`: Size, in bytes, of parts that files will be downloaded or uploaded in.
        Note: for saving checkpoints, the inner client will adjust the part size to meet the service limits.
        (max number of parts per upload is 10,000, minimum upload part size is 5 MiB).
        Part size must have values between 5MiB and 5GiB.
        8MB by default (may change in future).

- [X] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->
- Unit tests

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
