### PR TITLE
Build macOS wheels and integration tests

### DIFF
--- a/.github/workflows/ci-integration-main.yml
+++ b/.github/workflows/ci-integration-main.yml
@@ -2,7 +2,7 @@ name: Integration tests (Main)
 
 on:
   push:
-    branches: [ "main", "feature/*" ]
+    branches: [ "main", "feature/*", "workflow/*" ]
   merge_group:
     types: [ "checks_requested" ]
 

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -23,16 +23,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cargo cache
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -75,16 +71,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cargo cache
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -19,11 +19,12 @@ env:
 jobs:
   integration-test:
     name: Integration tests
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
       matrix:
+        runner: [ubuntu-22.04, macos-13]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         test-run:
           - name: "S3"
@@ -53,17 +54,13 @@ jobs:
           aws-region: ${{ vars.S3_REGION }}
 
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Restore Cargo cache
         id: restore-cargo-cache
         uses: actions/cache/restore@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -114,7 +111,6 @@ jobs:
         if: inputs.environment != 'integration-tests'
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -28,10 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@v1
@@ -47,17 +44,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cargo cache
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -78,10 +70,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build Rust tests
         run: cargo test --no-default-features --no-run --manifest-path s3torchconnectorclient/Cargo.toml

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           toolchain: stable
           override: true
-          submodules: true
 
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@v1
@@ -69,8 +68,11 @@ jobs:
         run: cargo clippy --all-targets --all-features --manifest-path s3torchconnectorclient/Cargo.toml
 
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     name: Rust tests
+    strategy:
+      matrix:
+        runner: [ubuntu-22.04, macos-13]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -80,7 +82,6 @@ jobs:
         with:
           toolchain: stable
           override: true
-          submodules: true
 
       - name: Build Rust tests
         run: cargo test --no-default-features --no-run --manifest-path s3torchconnectorclient/Cargo.toml

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,9 +43,9 @@ jobs:
           - runner: macos-13
             kind: macosx
             arch: x86_64
-#          - runner: macos-14
-#            kind: macosx
-#            arch: arm64
+          - runner: macos-14
+            kind: macosx
+            arch: arm64
     permissions:
       id-token: write
       contents: read
@@ -71,9 +71,18 @@ jobs:
         run: |
           mv NOTICE_DEFAULT THIRD-PARTY-LICENSES
 
+      # actions/setup-python requires /Users/runner/hostedtoolcache to exist to work properly
+      # with macosx due to fixed shared library path
+      # https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#macos
+      - name: Create hostedtoolcache dir for macosx
+        if: ${{ matrix.builder.kind == 'macosx' }}
+        run: |
+          mkdir -p /Users/runner/hostedtoolcache
+
       # actions/setup-python doesn't yet support ARM
       # https://github.com/actions/setup-python/issues/678
-      - if: ${{ matrix.builder.arch != 'aarch64' }}
+      - name: Setup Python
+        if: ${{ matrix.builder.arch != 'aarch64' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -81,6 +90,8 @@ jobs:
       - name: Install pipx
         run: |
           which python
+          which pip
+          python -m pip install --upgrade pip
           python -m pip install --upgrade pipx
           python -m pipx ensurepath
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,12 +19,12 @@ jobs:
     uses: ./.github/workflows/generate_third_party_licenses.yml
 
   build_wheels:
-    name: Build wheels for ${{ matrix.build_prefix }} - ${{ matrix.builder.arch }}
+    name: Wheels for ${{ matrix.python }} - ${{ matrix.builder.kind }} - ${{ matrix.builder.arch }}
     runs-on: ${{ matrix.builder.runner }}
     needs: generate_third_party_licenses
     strategy:
       matrix:
-        build_prefix:
+        python:
           - cp38
           - cp39
           - cp310
@@ -32,11 +32,20 @@ jobs:
           - cp312
         builder:
           - runner: codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
+            kind: manylinux
             arch: x86_64
           - runner: codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large
+            kind: manylinux
             arch: aarch64
 #          - runner: ubuntu-20.04
+#            kind: manylinux
 #            arch: x86_64
+          - runner: macos-13
+            kind: macosx
+            arch: x86_64
+          - runner: macos-14
+            kind: macosx
+            arch: arm64
     permissions:
       id-token: write
       contents: read
@@ -80,7 +89,7 @@ jobs:
           cibuildwheel
           "s3torchconnectorclient"
           --output-dir "wheelhouse"
-          --only "${{ matrix.build_prefix }}-manylinux_${{ matrix.builder.arch }}"
+          --only "${{ matrix.python }}-${{ matrix.builder.kind }}_${{ matrix.builder.arch }}"
           2>&1
         shell: bash
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,22 +19,17 @@ jobs:
     uses: ./.github/workflows/generate_third_party_licenses.yml
 
   build_wheels:
-    name: Wheels for ${{ matrix.python.id }} - ${{ matrix.builder.kind }} - ${{ matrix.builder.arch }}
+    name: Wheels for ${{ matrix.python }} - ${{ matrix.builder.kind }} - ${{ matrix.builder.arch }}
     runs-on: ${{ matrix.builder.runner }}
     needs: generate_third_party_licenses
     strategy:
       matrix:
         python:
-          - id: cp38
-            version: "3.8"
-          - id: cp39
-            version: "3.9"
-          - id: cp310
-            version: "3.10"
-          - id: cp311
-            version: "3.11"
-          - id: cp312
-            version: "3.12"
+          - cp38
+          - cp39
+          - cp310
+          - cp311
+          - cp312
         builder:
           - runner: codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
             kind: manylinux
@@ -48,9 +43,9 @@ jobs:
           - runner: macos-13
             kind: macosx
             arch: x86_64
-          - runner: macos-14
-            kind: macosx
-            arch: arm64
+#          - runner: macos-14
+#            kind: macosx
+#            arch: arm64
     permissions:
       id-token: write
       contents: read
@@ -81,14 +76,13 @@ jobs:
       - if: ${{ matrix.builder.arch != 'aarch64' }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python.version }}
-          cache: "pip"
+          python-version: "3.12"
 
       - name: Install pipx
         run: |
           which python
           python -m pip install --upgrade pipx
-          pipx ensurepath
+          python -m pipx ensurepath
 
       # Run cibuildwheel manually, as the current runner uses setup-python
       # https://github.com/pypa/cibuildwheel/issues/1623
@@ -97,7 +91,7 @@ jobs:
           cibuildwheel
           "s3torchconnectorclient"
           --output-dir "wheelhouse"
-          --only "${{ matrix.python.id }}-${{ matrix.builder.kind }}_${{ matrix.builder.arch }}"
+          --only "${{ matrix.python }}-${{ matrix.builder.kind }}_${{ matrix.builder.arch }}"
           2>&1
         shell: bash
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,17 +19,22 @@ jobs:
     uses: ./.github/workflows/generate_third_party_licenses.yml
 
   build_wheels:
-    name: Wheels for ${{ matrix.python }} - ${{ matrix.builder.kind }} - ${{ matrix.builder.arch }}
+    name: Wheels for ${{ matrix.python.id }} - ${{ matrix.builder.kind }} - ${{ matrix.builder.arch }}
     runs-on: ${{ matrix.builder.runner }}
     needs: generate_third_party_licenses
     strategy:
       matrix:
         python:
-          - cp38
-          - cp39
-          - cp310
-          - cp311
-          - cp312
+          - id: cp38
+            version: "3.8"
+          - id: cp39
+            version: "3.9"
+          - id: cp310
+            version: "3.10"
+          - id: cp311
+            version: "3.11"
+          - id: cp312
+            version: "3.12"
         builder:
           - runner: codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
             kind: manylinux
@@ -74,13 +79,16 @@ jobs:
       # actions/setup-python doesn't yet support ARM
       # https://github.com/actions/setup-python/issues/678
       - if: ${{ matrix.builder.arch != 'aarch64' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python.version }}
+          cache: "pip"
 
       - name: Install pipx
         run: |
-          python -m pip install --upgrade pipx 
+          which python
+          python -m pip install --upgrade pipx
+          pipx ensurepath
 
       # Run cibuildwheel manually, as the current runner uses setup-python
       # https://github.com/pypa/cibuildwheel/issues/1623
@@ -89,7 +97,7 @@ jobs:
           cibuildwheel
           "s3torchconnectorclient"
           --output-dir "wheelhouse"
-          --only "${{ matrix.python }}-${{ matrix.builder.kind }}_${{ matrix.builder.arch }}"
+          --only "${{ matrix.python.id }}-${{ matrix.builder.kind }}_${{ matrix.builder.arch }}"
           2>&1
         shell: bash
 

--- a/s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py
+++ b/s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py
@@ -22,6 +22,9 @@ from models.net import Net
 from models.lightning_transformer import LightningTransformer, L
 
 
+LIGHTNING_ACCELERATOR = "cpu"
+
+
 def test_save_and_load_checkpoint(checkpoint_directory):
     tensor = torch.rand(3, 10, 10)
     s3_lightning_checkpoint = S3LightningCheckpoint(region=checkpoint_directory.region)
@@ -77,7 +80,7 @@ def test_load_trained_checkpoint(checkpoint_directory):
     dataset = WikiText2(data_dir=Path(f"/tmp/data/{nonce}"))
     dataloader = DataLoader(dataset, num_workers=3)
     model = LightningTransformer(vocab_size=dataset.vocab_size)
-    trainer = L.Trainer(fast_dev_run=2)
+    trainer = L.Trainer(accelerator=LIGHTNING_ACCELERATOR, fast_dev_run=2)
     trainer.fit(model=model, train_dataloaders=dataloader)
     checkpoint_name = "lightning_module_training_checkpoint.pt"
     s3_uri = f"{checkpoint_directory.s3_uri}{checkpoint_name}"
@@ -96,6 +99,7 @@ def test_compatibility_with_trainer_plugins(checkpoint_directory):
     s3_lightning_checkpoint = S3LightningCheckpoint(region=checkpoint_directory.region)
     _verify_user_agent(s3_lightning_checkpoint)
     trainer = L.Trainer(
+        accelerator=LIGHTNING_ACCELERATOR,
         default_root_dir=checkpoint_directory.s3_uri,
         plugins=[s3_lightning_checkpoint],
         max_epochs=1,
@@ -130,6 +134,7 @@ def test_compatibility_with_checkpoint_callback(checkpoint_directory):
         enable_version_counter=True,
     )
     trainer = L.Trainer(
+        accelerator=LIGHTNING_ACCELERATOR,
         plugins=[s3_lightning_checkpoint],
         callbacks=[checkpoint_callback],
         min_epochs=4,
@@ -163,6 +168,7 @@ def test_compatibility_with_async_checkpoint_io(checkpoint_directory):
     async_s3_lightning_checkpoint = AsyncCheckpointIO(s3_lightning_checkpoint)
 
     trainer = L.Trainer(
+        accelerator=LIGHTNING_ACCELERATOR,
         default_root_dir=checkpoint_directory.s3_uri,
         plugins=[async_s3_lightning_checkpoint],
         min_epochs=4,
@@ -189,6 +195,7 @@ def test_compatibility_with_lightning_checkpoint_load(checkpoint_directory):
     model = LightningTransformer(vocab_size=dataset.vocab_size)
     s3_lightning_checkpoint = S3LightningCheckpoint(region=checkpoint_directory.region)
     trainer = L.Trainer(
+        accelerator=LIGHTNING_ACCELERATOR,
         default_root_dir=checkpoint_directory.s3_uri,
         plugins=[s3_lightning_checkpoint],
         max_epochs=1,


### PR DESCRIPTION
This is pretty simple, mostly just adding macos-13 (x86) and macos-14 (arm64) runners to the matrix. We also need to explicitly disable MPS for PyTorch to run correctly on the GHA runners which don't have access to that hardware.

--------
dnanuti@: Build on macos runners had occasionally a flaky behaviour, as `actions/setup-python` requires `/Users/runner/hostedtoolcache` to exist to work properly with macosx due to [fixed shared library path](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#macos).
Additionally, `pipx` was not always properly configured, depending on the runner image, encountered [this](https://github.com/actions/runner-images/issues/9607) on macos-14 arm64 runners too ([example run](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/8630946711/job/23658476975)).

Also worth mentioning:
>  Warning: While cibuildwheel can build CPython 3.8 universal2/arm64 wheels, we cannot test the arm64 part of them, even when running on an Apple Silicon machine. This is because we use the x86_64 installer of CPython 3.8. See the discussion in https://github.com/pypa/cibuildwheel/pull/1169 for the details. To silence this warning, set `CIBW_TEST_SKIP: "cp38-macosx_*:arm64"`.

This applies just for the build for 3.8 macosx arm64 and had the same behaviour with the [initial changes](https://github.com/awslabs/s3-connector-for-pytorch/commit/e353788fda75ed8f47091b87f9162d6f4863cd57).

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
