### PR TITLE
Add implementation of `readinto` to decrease amount of copy operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New features
 * Update S3ClientConfig to pass in the configuration for allowing unsigned requests, under boolean flag `unsigned`.
+* Improve the performance of `s3reader` when utilized with `pytorch.load` by incorporating support for the `readinto` method.
 
 
 ## v1.2.2 (March 22, 2024)

--- a/s3torchconnector/tst/e2e/test_e2e_s3checkpoint.py
+++ b/s3torchconnector/tst/e2e/test_e2e_s3checkpoint.py
@@ -2,13 +2,18 @@
 #  // SPDX-License-Identifier: BSD
 
 import torch
+import pytest
 
 from s3torchconnector import S3Checkpoint
 from models.net import Net
 
 
-def test_general_checkpointing(checkpoint_directory):
-    tensor = torch.tensor([[0.1, 1.2], [2.2, 3.1], [4.9, 5.2]])
+@pytest.mark.parametrize(
+    "tensor_dimensions",
+    [[3, 2], [10, 1024, 1024]],
+)
+def test_general_checkpointing(checkpoint_directory, tensor_dimensions):
+    tensor = torch.rand(tensor_dimensions)
     checkpoint_name = "general_checkpoint.pt"
     checkpoint = S3Checkpoint(region=checkpoint_directory.region)
     s3_uri = f"{checkpoint_directory.s3_uri}/{checkpoint_name}"

--- a/s3torchconnector/tst/unit/test_s3reader.py
+++ b/s3torchconnector/tst/unit/test_s3reader.py
@@ -21,7 +21,6 @@ logging.getLogger().setLevel(1)
 
 log = logging.getLogger(__name__)
 
-
 TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key"
 MOCK_OBJECT_INFO = Mock(ObjectInfo)
@@ -182,14 +181,17 @@ def test_over_read(stream: List[bytes], overread: int):
 def test_seeks_end():
     s3reader = S3Reader(TEST_BUCKET, TEST_KEY, lambda: None, lambda: iter([]))
     s3reader._size = 10
+    buf = memoryview(bytearray(10))
 
     assert s3reader.seek(0, SEEK_END) == 10
     assert s3reader.tell() == 10
     assert s3reader.read() == b""
+    assert s3reader.readinto(buf) == 0
 
     assert s3reader.seek(0, SEEK_CUR) == 10
     assert s3reader.tell() == 10
     assert s3reader.read() == b""
+    assert s3reader.readinto(buf) == 0
 
 
 def test_not_writable():
@@ -301,3 +303,110 @@ def test_s3reader_writes_size_after_read_all_explicit(stream: List[bytes]):
     assert s3reader.read(1) == b""
     # Once we've read past the end, we know how big the file is
     assert s3reader._size == total_length
+
+
+@given(
+    lists(binary(min_size=2, max_size=3), min_size=0, max_size=3),
+    integers(min_value=0, max_value=1),
+)
+def test_s3reader_readinto_buffer_smaller_then_chunks(
+    stream: List[bytes], buf_size: int
+):
+    s3reader = S3Reader(TEST_BUCKET, TEST_KEY, lambda: None, lambda: iter(stream))
+    assert s3reader._size is None
+    total_length = sum(map(len, stream))
+    buf = memoryview(bytearray(buf_size))
+    # We're able to read all the available data or the data that can be accommodated in buf
+    if buf_size > 0 and total_length > 0:
+        assert s3reader.readinto(buf) == buf_size
+        assert s3reader.tell() == buf_size
+        # We haven't reached the end yet
+        assert s3reader._size is None
+        # confirm that read data is the same as in source
+        assert buf[:buf_size] == (b"".join(stream))[:buf_size]
+    else:
+        assert s3reader.readinto(buf) == 0
+        assert s3reader.tell() == 0
+
+
+@given(
+    lists(binary(min_size=2, max_size=3), min_size=1, max_size=3),
+    integers(min_value=3, max_value=10),
+)
+def test_s3reader_readinto_buffer_bigger_then_chunks(
+    stream: List[bytes], buf_size: int
+):
+    s3reader = S3Reader(TEST_BUCKET, TEST_KEY, lambda: None, lambda: iter(stream))
+    assert s3reader._size is None
+    total_length = sum(map(len, stream))
+    buf = memoryview(bytearray(buf_size))
+    should_read_bytes_in_first_pass = min(buf_size, total_length)
+    # We're able to read all the available data or the data that can be accommodated in buf
+    assert s3reader.readinto(buf) == should_read_bytes_in_first_pass
+    assert s3reader.tell() == should_read_bytes_in_first_pass
+    all_data = b"".join(stream)
+    # confirm that read data is the same as in source
+    assert (
+        buf[:should_read_bytes_in_first_pass]
+        == all_data[:should_read_bytes_in_first_pass]
+    )
+    if total_length < buf_size:
+        assert s3reader._size == total_length
+
+    should_read_bytes_in_second_pass = max(
+        min(buf_size, total_length - should_read_bytes_in_first_pass), 0
+    )
+    if should_read_bytes_in_second_pass > 0:
+        # We're able to read all the available data or the data that can be accommodated in buf
+        assert s3reader.readinto(buf) == should_read_bytes_in_second_pass
+        total_read = should_read_bytes_in_first_pass + should_read_bytes_in_second_pass
+        assert s3reader.tell() == total_read
+        # confirm that read data is the same as in source
+        assert (
+            buf[:should_read_bytes_in_second_pass]
+            == all_data[should_read_bytes_in_first_pass:total_read]
+        )
+        if total_length < total_read:
+            assert s3reader._size == total_read
+
+
+@given(
+    lists(binary(min_size=2, max_size=12), min_size=1, max_size=5),
+    integers(min_value=3, max_value=10),
+    integers(min_value=0, max_value=1),
+)
+def test_s3reader_mixing_readinto_and_read(
+    stream: List[bytes], buf_size: int, flip: int
+):
+    position = 0
+    loops_count = 20
+    all_data = b"".join(stream)
+    total_length = len(all_data)
+    buf = memoryview(bytearray(buf_size))
+    s3reader = S3Reader(TEST_BUCKET, TEST_KEY, lambda: None, lambda: iter(stream))
+    for i in range(0, loops_count):
+        if position >= total_length:
+            break
+
+        if (i + flip) % 2 == 0:
+            result = s3reader.read(buf_size)
+            # confirm that read data is the same as in source
+            if position + buf_size < total_length:
+                assert result[:buf_size] == all_data[position : position + buf_size]
+            else:
+                read_bytes = total_length - position
+                assert result[:read_bytes] == all_data[position:total_length]
+            position += buf_size
+        else:
+            read_bytes = s3reader.readinto(buf)
+            # confirm that read data is the same as in source
+            assert buf[position:read_bytes] == all_data[position:read_bytes]
+            position += read_bytes
+
+        if position > total_length:
+            # we read all the data, it is time to stop
+            assert s3reader.tell() == total_length
+            break
+        else:
+            # confirm that position is as expected
+            assert s3reader.tell() == position


### PR DESCRIPTION
## Description
Changes to address https://github.com/awslabs/s3-connector-for-pytorch/issues/199
PyTorch compresses a model's data before storing it as a checkpoint. When loading a checkpoint with PyTorch, we need to decompress the stored compressed data. The process of loading this compressed data is not executed sequentially. During the loading process, it jumps back and forth through the stream representing the checkpoint to read separate chunks of data. This required us to create copies of these data parts and return them to PyTorch for processing. However, PyTorch supports an alternative way to obtain a copy of that data. If the object passed to `torch.load` supports the `readinto` method, then PyTorch will provide a pre-allocated buffer for writing that data directly, without the need for creating intermediate copies. See [here](https://github.com/pytorch/pytorch/blob/1e8d4b389b5f03cea191ed558051f036fe04f92d/torch/csrc/jit/python/init.cpp#L1500C11-L1511)

## Additional context
Add to `s3reader` implementation of `readinto` to decrease amount of copy operations. That allows to decrease the checkpoint loading time from 28 to 15 seconds on g5.12xlarge instance, while running test script from https://github.com/awslabs/s3-connector-for-pytorch/issues/199


- [x] I have updated the CHANGELOG or README if appropriate

## Related items
https://github.com/awslabs/s3-connector-for-pytorch/issues/199

## Testing
- Unit test was updated to test new `readinto` method of `s3reader`.
- Integration test for saving/loading checkpoint was extended to run test for ~40mb checkpoint, that will be bigger than default part_size.
- Test script from https://github.com/awslabs/s3-connector-for-pytorch/issues/199 was used to confirm performance improvement during checkpoint loading.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
