### PR TITLE
Added support for passing a custom endpoint to S3LightningCheckpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New features
 * Update S3ClientConfig to pass in the configuration for allowing unsigned requests, under boolean flag `unsigned`.
 * Improve the performance of `s3reader` when utilized with `pytorch.load` by incorporating support for the `readinto` method.
+* Add support for passing an optional custom endpoint to S3LightningCheckpoint constructor method.
 
 
 ## v1.2.2 (March 22, 2024)

--- a/s3torchconnector/src/s3torchconnector/lightning/s3_lightning_checkpoint.py
+++ b/s3torchconnector/src/s3torchconnector/lightning/s3_lightning_checkpoint.py
@@ -20,6 +20,7 @@ class S3LightningCheckpoint(CheckpointIO):
         self,
         region: str,
         s3client_config: Optional[S3ClientConfig] = None,
+        endpoint: Optional[str] = None,
     ):
         self.region = region
         user_agent = UserAgent(["lightning", lightning.__version__])
@@ -27,6 +28,7 @@ class S3LightningCheckpoint(CheckpointIO):
             region,
             user_agent=user_agent,
             s3client_config=s3client_config,
+            endpoint=endpoint,
         )
 
     def save_checkpoint(

--- a/s3torchconnector/tst/unit/lightning/test_s3_lightning_checkpoint.py
+++ b/s3torchconnector/tst/unit/lightning/test_s3_lightning_checkpoint.py
@@ -27,6 +27,7 @@ from s3torchconnectorclient import S3Exception
 TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key"
 TEST_REGION = "us-east-1"
+TEST_ENDPOINT = "https://s3.us-east-1.amazonaws.com"
 
 
 @pytest.fixture()
@@ -146,6 +147,11 @@ def test_invalid_path(lightning_checkpoint, checkpoint_method_name, kwargs):
 def test_teardown(lightning_checkpoint):
     lightning_checkpoint.teardown()
     # Assert no exception is thrown - implicit
+
+
+def test_lightning_checkpoint_creation_with_region_and_endpoint():
+    checkpoint = S3LightningCheckpoint(TEST_REGION, endpoint=TEST_ENDPOINT)
+    assert isinstance(checkpoint, S3LightningCheckpoint)
 
 
 def _test_save(


### PR DESCRIPTION
## Description
Added support for passing a custom endpoint to S3LightningCheckpoint. An endpoint optional argument is added to S3LightningCheckpoint constructor. 

## Additional context
Added a unit test case for lightning module. Tested with a customer S3 storage system.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
