### PR TITLE
Add path-style addressing support

### DIFF
--- a/s3torchconnector/src/s3torchconnector/_s3client/_mock_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_mock_s3client.py
@@ -38,6 +38,7 @@ class MockS3Client(S3Client):
             part_size=self.s3client_config.part_size,
             user_agent_prefix=self.user_agent_prefix,
             unsigned=self.s3client_config.unsigned,
+            force_path_style=self.s3client_config.force_path_style,
         )
 
     def add_object(self, key: str, data: bytes) -> None:

--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -78,6 +78,7 @@ class S3Client:
             throughput_target_gbps=self._s3client_config.throughput_target_gbps,
             part_size=self._s3client_config.part_size,
             unsigned=self._s3client_config.unsigned,
+            force_path_style=self._s3client_config.force_path_style,
         )
 
     def get_object(

--- a/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
@@ -15,8 +15,10 @@ class S3ClientConfig:
         (max number of parts per upload is 10,000, minimum upload part size is 5 MiB).
         Part size must have values between 5MiB and 5GiB.
         8MiB by default (may change in future).
+    force_path_style(bool): forceful path style addressing for S3 client.
     """
 
     throughput_target_gbps: float = 10.0
     part_size: int = 8 * 1024 * 1024
     unsigned: bool = False
+    force_path_style: bool = False

--- a/s3torchconnector/tst/unit/test_s3_client.py
+++ b/s3torchconnector/tst/unit/test_s3_client.py
@@ -139,3 +139,11 @@ def test_unsigned_s3_client():
         s3client_config=S3ClientConfig(unsigned=True),
     )
     assert s3_client._client.unsigned is True
+
+
+def test_force_path_style_s3_client():
+    s3_client = S3Client(
+        region=TEST_REGION,
+        s3client_config=S3ClientConfig(force_path_style=True),
+    )
+    assert s3_client._client.force_path_style is True

--- a/s3torchconnector/tst/unit/test_s3_client_config.py
+++ b/s3torchconnector/tst/unit/test_s3_client_config.py
@@ -11,6 +11,12 @@ def test_default():
     config = S3ClientConfig()
     assert config.part_size == 8 * MiB
     assert config.throughput_target_gbps == 10.0
+    assert config.force_path_style is False
+
+
+def test_enable_force_path_style():
+    config = S3ClientConfig(force_path_style=True)
+    assert config.force_path_style is True
 
 
 @given(part_size=integers(min_value=5 * MiB, max_value=5 * GiB))

--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/_mountpoint_s3_client.pyi
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/_mountpoint_s3_client.pyi
@@ -11,6 +11,7 @@ class MountpointS3Client:
     part_size: int
     profile: Optional[str]
     unsigned: Optional[bool]
+    force_path_style: Optional[bool]
     user_agent_prefix: str
     endpoint: str
 
@@ -23,6 +24,7 @@ class MountpointS3Client:
         profile: Optional[str] = None,
         unsigned: Optional[bool] = False,
         endpoint: Optional[str] = None,
+        force_path_style: Optional[bool] = False,
     ): ...
     def get_object(self, bucket: str, key: str) -> GetObjectStream: ...
     def put_object(
@@ -40,6 +42,7 @@ class MockMountpointS3Client:
     part_size: int
     user_agent_prefix: str
     unsigned: bool
+    force_path_style: bool
 
     def __init__(
         self,
@@ -50,6 +53,7 @@ class MockMountpointS3Client:
         part_size: int = 8 * 1024 * 1024,
         user_agent_prefix: str = "mock_client",
         unsigned: bool = False,
+        force_path_style: bool = False,
     ): ...
     def create_mocked_client(self) -> MountpointS3Client: ...
     def add_object(self, key: str, data: bytes) -> None: ...

--- a/s3torchconnectorclient/python/tst/integration/test_mountpoint_s3_integration.py
+++ b/s3torchconnectorclient/python/tst/integration/test_mountpoint_s3_integration.py
@@ -33,8 +33,13 @@ HELLO_WORLD_DATA = b"Hello, World!\n"
 TEST_USER_AGENT_PREFIX = "integration-tests"
 
 
-def test_get_object(sample_directory: BucketPrefixFixture):
-    client = MountpointS3Client(sample_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object(sample_directory: BucketPrefixFixture, force_path_style: bool):
+    client = MountpointS3Client(
+        sample_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     stream = client.get_object(
         sample_directory.bucket, f"{sample_directory.prefix}hello_world.txt"
     )
@@ -57,9 +62,14 @@ def test_get_object_with_endpoint(sample_directory: BucketPrefixFixture):
     assert full_data == HELLO_WORLD_DATA
 
 
-def test_get_object_with_unpickled_client(sample_directory: BucketPrefixFixture):
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_with_unpickled_client(
+    sample_directory: BucketPrefixFixture, force_path_style: bool
+):
     original_client = MountpointS3Client(
-        sample_directory.region, TEST_USER_AGENT_PREFIX
+        sample_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
     )
     assert original_client.user_agent_prefix == TEST_USER_AGENT_PREFIX
     pickled_client = pickle.dumps(original_client)
@@ -73,8 +83,15 @@ def test_get_object_with_unpickled_client(sample_directory: BucketPrefixFixture)
     assert full_data == HELLO_WORLD_DATA
 
 
-def test_get_object_invalid_bucket(sample_directory: BucketPrefixFixture):
-    client = MountpointS3Client(sample_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_invalid_bucket(
+    sample_directory: BucketPrefixFixture, force_path_style: bool
+):
+    client = MountpointS3Client(
+        sample_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     with pytest.raises(S3Exception, match="Service error: The bucket does not exist"):
         next(
             client.get_object(
@@ -83,8 +100,15 @@ def test_get_object_invalid_bucket(sample_directory: BucketPrefixFixture):
         )
 
 
-def test_get_object_invalid_prefix(sample_directory: BucketPrefixFixture):
-    client = MountpointS3Client(sample_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_invalid_prefix(
+    sample_directory: BucketPrefixFixture, force_path_style: bool
+):
+    client = MountpointS3Client(
+        sample_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     with pytest.raises(S3Exception, match="Service error: The key does not exist"):
         next(
             client.get_object(
@@ -93,8 +117,13 @@ def test_get_object_invalid_prefix(sample_directory: BucketPrefixFixture):
         )
 
 
-def test_list_objects(image_directory: BucketPrefixFixture):
-    client = MountpointS3Client(image_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_list_objects(image_directory: BucketPrefixFixture, force_path_style: bool):
+    client = MountpointS3Client(
+        image_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     stream = client.list_objects(image_directory.bucket)
 
     object_infos = [object_info for page in stream for object_info in page.object_info]
@@ -107,8 +136,15 @@ def test_list_objects(image_directory: BucketPrefixFixture):
     assert keys > expected_img_10_keys
 
 
-def test_list_objects_with_prefix(image_directory: BucketPrefixFixture):
-    client = MountpointS3Client(image_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_list_objects_with_prefix(
+    image_directory: BucketPrefixFixture, force_path_style: bool
+):
+    client = MountpointS3Client(
+        image_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     stream = client.list_objects(image_directory.bucket, image_directory.prefix)
 
     object_infos = [object_info for page in stream for object_info in page.object_info]
@@ -120,8 +156,15 @@ def test_list_objects_with_prefix(image_directory: BucketPrefixFixture):
     assert keys == expected_img_10_keys
 
 
-def test_multi_list_requests_return_same_list(image_directory: BucketPrefixFixture):
-    client = MountpointS3Client(image_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_multi_list_requests_return_same_list(
+    image_directory: BucketPrefixFixture, force_path_style: bool
+):
+    client = MountpointS3Client(
+        image_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     stream = client.list_objects(image_directory.bucket, image_directory.prefix)
 
     object_infos = [object_info for page in stream for object_info in page.object_info]
@@ -148,11 +191,17 @@ def test_multi_list_requests_return_same_list(image_directory: BucketPrefixFixtu
         ),
     ],
 )
+@pytest.mark.parametrize("force_path_style", [False, True])
 def test_put_object(
-    filename: str, content: bytes, put_object_tests_directory: BucketPrefixFixture
+    filename: str,
+    content: bytes,
+    put_object_tests_directory: BucketPrefixFixture,
+    force_path_style: bool,
 ):
     client = MountpointS3Client(
-        put_object_tests_directory.region, TEST_USER_AGENT_PREFIX
+        put_object_tests_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
     )
     put_stream = client.put_object(
         put_object_tests_directory.bucket,
@@ -169,9 +218,14 @@ def test_put_object(
     assert b"".join(get_stream) == content
 
 
-def test_put_object_overwrite(put_object_tests_directory: BucketPrefixFixture):
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_put_object_overwrite(
+    put_object_tests_directory: BucketPrefixFixture, force_path_style: bool
+):
     client = MountpointS3Client(
-        put_object_tests_directory.region, TEST_USER_AGENT_PREFIX
+        put_object_tests_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
     )
 
     put_stream = client.put_object(
@@ -198,10 +252,15 @@ def test_put_object_overwrite(put_object_tests_directory: BucketPrefixFixture):
 
 
 @pytest.mark.parametrize("max_keys", {1, 4, 1000})
+@pytest.mark.parametrize("force_path_style", [False, True])
 def test_s3_list_object_with_continuation(
-    max_keys: int, image_directory: BucketPrefixFixture
+    max_keys: int, image_directory: BucketPrefixFixture, force_path_style: bool
 ):
-    client = MountpointS3Client(image_directory.region, TEST_USER_AGENT_PREFIX)
+    client = MountpointS3Client(
+        image_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     stream = client.list_objects(
         image_directory.bucket, prefix=image_directory.prefix, max_keys=max_keys
     )
@@ -240,13 +299,20 @@ def test_s3_list_object_with_continuation(
         ),
     ],
 )
+@pytest.mark.parametrize("force_path_style", [False, True])
 def test_put_object_mpu(
-    part_count: int, part_size: int, put_object_tests_directory: BucketPrefixFixture
+    part_count: int,
+    part_size: int,
+    put_object_tests_directory: BucketPrefixFixture,
+    force_path_style: bool,
 ):
     data_to_write = randbytes(part_count * part_size)
 
     client = MountpointS3Client(
-        put_object_tests_directory.region, TEST_USER_AGENT_PREFIX, part_size=part_size
+        put_object_tests_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        part_size=part_size,
+        force_path_style=force_path_style,
     )
 
     put_stream = client.put_object(
@@ -263,8 +329,13 @@ def test_put_object_mpu(
     assert b"".join(get_stream) == data_to_write
 
 
-def test_head_object(sample_directory: BucketPrefixFixture):
-    client = MountpointS3Client(sample_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_head_object(sample_directory: BucketPrefixFixture, force_path_style: bool):
+    client = MountpointS3Client(
+        sample_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     object_info = client.head_object(
         sample_directory.bucket,
         f"{sample_directory.prefix}hello_world.txt",
@@ -283,8 +354,13 @@ def test_head_object(sample_directory: BucketPrefixFixture):
         assert object_info.etag == expected_etag
 
 
-def test_delete_object(sample_directory: BucketPrefixFixture):
-    client = MountpointS3Client(sample_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_delete_object(sample_directory: BucketPrefixFixture, force_path_style: bool):
+    client = MountpointS3Client(
+        sample_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     client.delete_object(
         sample_directory.bucket,
         f"{sample_directory.prefix}hello_world.txt",
@@ -298,16 +374,30 @@ def test_delete_object(sample_directory: BucketPrefixFixture):
         )
 
 
-def test_delete_object_does_not_exist(empty_directory: BucketPrefixFixture):
-    client = MountpointS3Client(empty_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_delete_object_does_not_exist(
+    empty_directory: BucketPrefixFixture, force_path_style: bool
+):
+    client = MountpointS3Client(
+        empty_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     client.delete_object(
         empty_directory.bucket, f"{empty_directory.prefix}hello_world.txt"
     )
     # Assert no exception is thrown in case the object already doesn't exist - implicit
 
 
-def test_delete_object_invalid_bucket(empty_directory: BucketPrefixFixture):
-    client = MountpointS3Client(empty_directory.region, TEST_USER_AGENT_PREFIX)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_delete_object_invalid_bucket(
+    empty_directory: BucketPrefixFixture, force_path_style: bool
+):
+    client = MountpointS3Client(
+        empty_directory.region,
+        TEST_USER_AGENT_PREFIX,
+        force_path_style=force_path_style,
+    )
     with pytest.raises(S3Exception, match="Service error: The bucket does not exist"):
         client.delete_object(
             f"{empty_directory.bucket}-{uuid.uuid4()}", empty_directory.prefix

--- a/s3torchconnectorclient/python/tst/unit/test_mountpoint_s3_client.py
+++ b/s3torchconnectorclient/python/tst/unit/test_mountpoint_s3_client.py
@@ -33,8 +33,11 @@ INVALID_ENDPOINT = "INVALID"
         ("multipart", b"The quick brown fox jumps over the lazy dog.", 2),
     ],
 )
-def test_get_object(key: str, data: bytes, part_size: int):
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET, part_size=part_size)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object(key: str, data: bytes, part_size: int, force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, part_size=part_size, force_path_style=force_path_style
+    )
     mock_client.add_object(key, data)
     client = mock_client.create_mocked_client()
 
@@ -45,8 +48,11 @@ def test_get_object(key: str, data: bytes, part_size: int):
     assert returned_data == data
 
 
-def test_get_object_part_size():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET, part_size=2)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_part_size(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, part_size=2, force_path_style=force_path_style
+    )
     mock_client.add_object("key", b"1234567890")
     client = mock_client.create_mocked_client()
 
@@ -62,32 +68,44 @@ def test_get_object_part_size():
         assert stream.tell() == expected_position
 
 
-def test_get_object_bad_bucket():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_bad_bucket(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     client = mock_client.create_mocked_client()
 
     with pytest.raises(S3Exception, match="Service error: The bucket does not exist"):
         client.get_object("does_not_exist", "foo")
 
 
-def test_get_object_none_bucket():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_none_bucket(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     client = mock_client.create_mocked_client()
 
     with pytest.raises(TypeError):
         client.get_object(None, "foo")
 
 
-def test_get_object_bad_object():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_bad_object(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     client = mock_client.create_mocked_client()
 
     with pytest.raises(S3Exception, match="Service error: The key does not exist"):
         client.get_object(MOCK_BUCKET, "does_not_exist")
 
 
-def test_get_object_iterates_once():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_iterates_once(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     mock_client.add_object("key", b"data")
     client = mock_client.create_mocked_client()
 
@@ -101,8 +119,11 @@ def test_get_object_iterates_once():
     assert returned_data == b""
 
 
-def test_get_object_throws_stop_iteration():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_get_object_throws_stop_iteration(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     mock_client.add_object("key", b"data")
     client = mock_client.create_mocked_client()
 
@@ -125,8 +146,11 @@ def test_get_object_throws_stop_iteration():
         (set()),
     ],
 )
-def test_list_objects(expected_keys: Set[str]):
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_list_objects(expected_keys: Set[str], force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     for key in expected_keys:
         mock_client.add_object(key, b"")
     client = mock_client.create_mocked_client()
@@ -151,8 +175,13 @@ def test_list_objects(expected_keys: Set[str]):
         ("test", set(), set()),
     ],
 )
-def test_list_objects_with_prefix(prefix: str, keys: Set[str], expected_keys: Set[str]):
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_list_objects_with_prefix(
+    prefix: str, keys: Set[str], expected_keys: Set[str], force_path_style: bool
+):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     for key in keys:
         mock_client.add_object(key, b"")
     client = mock_client.create_mocked_client()
@@ -174,8 +203,11 @@ def test_list_objects_with_prefix(prefix: str, keys: Set[str], expected_keys: Se
         (b"", 2000),
     ],
 )
-def test_put_object(data_to_write: bytes, part_size: int):
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET, part_size=part_size)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_put_object(data_to_write: bytes, part_size: int, force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, part_size=part_size, force_path_style=force_path_style
+    )
     client = mock_client.create_mocked_client()
 
     put_stream = client.put_object(MOCK_BUCKET, "key")
@@ -188,8 +220,11 @@ def test_put_object(data_to_write: bytes, part_size: int):
     assert b"".join(get_stream) == data_to_write
 
 
-def test_put_object_overwrite():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_put_object_overwrite(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     mock_client.add_object("key", b"before")
     client = mock_client.create_mocked_client()
 
@@ -203,8 +238,11 @@ def test_put_object_overwrite():
     assert b"".join(get_stream) == b"after"
 
 
-def test_put_object_no_multiple_close():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_put_object_no_multiple_close(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     client = mock_client.create_mocked_client()
 
     put_stream = client.put_object(MOCK_BUCKET, "key")
@@ -216,8 +254,11 @@ def test_put_object_no_multiple_close():
         put_stream.close()
 
 
-def test_put_object_no_write_after_close():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_put_object_no_write_after_close(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     client = mock_client.create_mocked_client()
 
     put_stream = client.put_object(MOCK_BUCKET, "key")
@@ -229,8 +270,11 @@ def test_put_object_no_write_after_close():
         put_stream.write(b"")
 
 
-def test_put_object_with_storage_class():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_put_object_with_storage_class(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     client = mock_client.create_mocked_client()
 
     put_stream = client.put_object(MOCK_BUCKET, "key", "STANDARD_IA")
@@ -247,6 +291,7 @@ def test_mountpoint_client_pickles():
     expected_region = REGION
     expected_part_size = 5 * 2**20
     expected_throughput_target_gbps = 3.5
+    expected_force_path_style = True
 
     client = MountpointS3Client(
         region=expected_region,
@@ -255,6 +300,7 @@ def test_mountpoint_client_pickles():
         throughput_target_gbps=expected_throughput_target_gbps,
         profile=expected_profile,
         unsigned=expected_unsigned,
+        force_path_style=expected_force_path_style,
     )
     dumped = pickle.dumps(client)
     loaded = pickle.loads(dumped)
@@ -272,6 +318,9 @@ def test_mountpoint_client_pickles():
     )
     assert client.profile == loaded.profile == expected_profile
     assert client.unsigned == loaded.unsigned == expected_unsigned
+    assert (
+        client.force_path_style == loaded.force_path_style == expected_force_path_style
+    )
 
 
 @pytest.mark.parametrize(
@@ -283,12 +332,18 @@ def test_mountpoint_client_pickles():
         ("https://us-east-1.amazonaws.com", "https://us-east-1.amazonaws.com"),
     ],
 )
+@pytest.mark.parametrize("force_path_style", [False, True])
 def test_mountpoint_client_creation_with_region_and_endpoint(
-    endpoint: Optional[str], expected: Optional[str]
+    endpoint: Optional[str],
+    expected: Optional[str],
+    force_path_style: bool,
 ):
-    client = MountpointS3Client(region=REGION, endpoint=endpoint)
+    client = MountpointS3Client(
+        region=REGION, endpoint=endpoint, force_path_style=force_path_style
+    )
     assert isinstance(client, MountpointS3Client)
     assert client.endpoint == expected
+    assert client.force_path_style == force_path_style
 
 
 def test_mountpoint_client_creation_with_region_and_invalid_endpoint():
@@ -303,9 +358,12 @@ def test_mountpoint_client_creation_with_region_and_invalid_endpoint():
     )
 
 
-def test_delete_object():
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_delete_object(force_path_style: bool):
     key = "hello_world.txt"
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     mock_client.add_object(key, b"data")
     client = mock_client.create_mocked_client()
 
@@ -315,15 +373,19 @@ def test_delete_object():
         client.get_object(MOCK_BUCKET, key)
 
 
-def test_delete_object_already_deleted():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_delete_object_already_deleted(force_path_style: bool):
+    mock_client = MockMountpointS3Client(
+        REGION, MOCK_BUCKET, force_path_style=force_path_style
+    )
     client = mock_client.create_mocked_client()
 
     client.delete_object(MOCK_BUCKET, "hello_world.txt")
 
 
-def test_delete_object_non_existent_bucket():
-    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET)
+@pytest.mark.parametrize("force_path_style", [False, True])
+def test_delete_object_non_existent_bucket(force_path_style: bool):
+    mock_client = MockMountpointS3Client(REGION, MOCK_BUCKET, force_path_style)
     client = mock_client.create_mocked_client()
 
     with pytest.raises(S3Exception, match="Service error: The bucket does not exist"):

--- a/s3torchconnectorclient/rust/src/mock_client.rs
+++ b/s3torchconnectorclient/rust/src/mock_client.rs
@@ -28,12 +28,14 @@ pub struct PyMockClient {
     pub(crate) user_agent_prefix: String,
     #[pyo3(get)]
     pub(crate) unsigned: bool,
+    #[pyo3(get)]
+    pub(crate) force_path_style: bool,
 }
 
 #[pymethods]
 impl PyMockClient {
     #[new]
-    #[pyo3(signature = (region, bucket, throughput_target_gbps = 10.0, part_size = 8 * 1024 * 1024, user_agent_prefix="mock_client".to_string(), unsigned=false))]
+    #[pyo3(signature = (region, bucket, throughput_target_gbps = 10.0, part_size = 8 * 1024 * 1024, user_agent_prefix="mock_client".to_string(), unsigned=false, force_path_style=false))]
     pub fn new(
         region: String,
         bucket: String,
@@ -41,6 +43,7 @@ impl PyMockClient {
         part_size: usize,
         user_agent_prefix: String,
         unsigned: bool,
+        force_path_style: bool,
     ) -> PyMockClient {
         let unordered_list_seed: Option<u64> = None;
         let config = MockClientConfig { bucket, part_size, unordered_list_seed, ..Default::default() };
@@ -52,7 +55,8 @@ impl PyMockClient {
             throughput_target_gbps,
             part_size,
             user_agent_prefix,
-            unsigned
+            unsigned,
+            force_path_style
         }
     }
 
@@ -64,6 +68,7 @@ impl PyMockClient {
             self.part_size,
             None,
             self.unsigned,
+            self.force_path_style,
             self.mock_client.clone(),
             None,
         )

--- a/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
+++ b/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use mountpoint_s3_crt::common::uri::Uri;
 use mountpoint_s3_crt::common::allocator::Allocator;
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientAuthConfig, S3ClientConfig};
+use mountpoint_s3_client::config::{AddressingStyle, EndpointConfig, S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::types::PutObjectParams;
 use mountpoint_s3_client::user_agent::UserAgent;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
@@ -43,6 +43,8 @@ pub struct MountpointS3Client {
     #[pyo3(get)]
     unsigned: bool,
     #[pyo3(get)]
+    force_path_style: bool,
+    #[pyo3(get)]
     user_agent_prefix: String,
     #[pyo3(get)]
     endpoint: Option<String>,
@@ -53,7 +55,8 @@ pub struct MountpointS3Client {
 #[pymethods]
 impl MountpointS3Client {
     #[new]
-    #[pyo3(signature = (region, user_agent_prefix="".to_string(), throughput_target_gbps=10.0, part_size=8*1024*1024, profile=None, unsigned=false, endpoint=None))]
+    #[pyo3(signature = (region, user_agent_prefix="".to_string(), throughput_target_gbps=10.0, part_size=8*1024*1024, profile=None, unsigned=false, endpoint=None, force_path_style=false))]
+    #[allow(clippy::too_many_arguments)]
     pub fn new_s3_client(
         region: String,
         user_agent_prefix: String,
@@ -62,16 +65,20 @@ impl MountpointS3Client {
         profile: Option<String>,
         unsigned: bool,
         endpoint: Option<String>,
+        force_path_style: bool,
     ) -> PyResult<Self> {
         // TODO: Mountpoint has logic for guessing based on instance type. It may be worth having
         // similar logic if we want to exceed 10Gbps reading for larger instances
 
         let endpoint_str = endpoint.as_deref().unwrap_or("");
-        let endpoint_config = if endpoint_str.is_empty() {
+        let mut endpoint_config = if endpoint_str.is_empty() {
             EndpointConfig::new(&region)
         } else {
             EndpointConfig::new(&region).endpoint(Uri::new_from_str(&Allocator::default(), endpoint_str).unwrap())
         };
+        if force_path_style {
+            endpoint_config = endpoint_config.addressing_style(AddressingStyle::Path);
+        }
         let auth_config = auth_config(profile.as_deref(), unsigned);
 
         let user_agent_suffix =
@@ -97,6 +104,7 @@ impl MountpointS3Client {
             part_size,
             profile,
             unsigned,
+            force_path_style,
             crt_client,
             endpoint,
         ))
@@ -156,6 +164,7 @@ impl MountpointS3Client {
             slf.profile.to_object(py),
             slf.unsigned.to_object(py),
             slf.endpoint.to_object(py),
+            slf.force_path_style.to_object(py),
         ];
         Ok(PyTuple::new(py, state))
     }
@@ -171,6 +180,7 @@ impl MountpointS3Client {
         profile: Option<String>,
         // no_sign_request on mountpoint-s3-client
         unsigned: bool,
+        force_path_style: bool,
         client: Arc<Client>,
         endpoint: Option<String>,
     ) -> Self
@@ -185,6 +195,7 @@ impl MountpointS3Client {
             region,
             profile,
             unsigned,
+            force_path_style,
             client: Arc::new(MountpointS3ClientInnerImpl::new(client)),
             user_agent_prefix,
             endpoint,


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/doc/DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
This PR extends support to other S3 object storage like MinIO which has path-style addressing to access bucket/object.

An example is like
```py
from s3torchconnector import S3ClientConfig, S3MapDataset, S3IterableDataset

DATASET_URI="s3://<BUCKET>/<PREFIX>"
REGION = "us-east-1"
s3client_config = S3ClientConfig(force_path_style=True)

iterable_dataset = S3IterableDataset.from_prefix(DATASET_URI, region=REGION, s3client_config=s3client_config)

for item in iterable_dataset:
  print(item.key)

map_dataset = S3MapDataset.from_prefix(DATASET_URI, region=REGION, s3client_config=s3client_config)

item = map_dataset[0]

bucket = item.bucket
key = item.key
content = item.read()
len(content)
```

And

```py
from s3torchconnector import S3Checkpoint, S3ClientConfig

import torchvision
import torch

CHECKPOINT_URI="s3://<BUCKET>/<KEY>/"
REGION = "us-east-1"
s3client_config = S3ClientConfig(force_path_style=True)
checkpoint = S3Checkpoint(region=REGION, s3client_config=s3client_config)

model = torchvision.models.resnet18()

with checkpoint.writer(CHECKPOINT_URI + "epoch0.ckpt") as writer:
    torch.save(model.state_dict(), writer)

with checkpoint.reader(CHECKPOINT_URI + "epoch0.ckpt") as reader:
    state_dict = torch.load(reader)

model.load_state_dict(state_dict)
```


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->


- [ ] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
Fixes https://github.com/awslabs/s3-connector-for-pytorch/issues/208

## Testing
<!-- Please describe how these changes were tested. -->
The example code is run against `play.min.io` and it worked as expected.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
