### PR TITLE
Conditionally modify YUM repositories for aarch64

### DIFF
--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -76,16 +76,12 @@ skip = "*musllinux* *i686"
 [tool.cibuildwheel.linux]
 before-all = [
   "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
-  "yum install -y epel-release centos-release-scl",
+  "bash -c 'platform=$(uname -p); if [ \"$platform\" == \"aarch64\" ]; then sed -i \"s|centos/7|altarch/7|g\" /etc/yum.repos.d/*.repo; fi'",
   "yum install -y fuse",
   "yum install -y fuse-devel",
   "yum install -y make",
-  "yum install -y cmake3",
   "yum install -y git",
   "yum install -y pkgconfig",
-  "yum install -y dpkg",
-  "yum install -y fakeroot",
-  "yum install -y rpmdevtools",
   "yum install -y tar",
   "yum install -y wget",
   "yum install -y devtoolset-10-gcc",


### PR DESCRIPTION
## Description
Centos 7 reached its End Of Life which lead to deprecation of official mirrors. cibuildwheels made changes to re-targed `yum` to vault with frozen packages, but it was lacking packages for aarch64 platform. Removing unnecessary packages helped to resolve that problem.

- [x] I have updated the CHANGELOG or README if appropriate

## Testing
Run wheels build workflow

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
