### PR TITLE
Added printing of errors for more visibility in case of exceptions during multipart uploads.

### DIFF
--- a/s3torchconnectorclient/rust/src/exception.rs
+++ b/s3torchconnectorclient/rust/src/exception.rs
@@ -15,6 +15,10 @@ pyo3::create_exception!(
     PyException
 );
 
+fn log_error(message: &str) {
+    println!("ERROR: {}", message);
+}
+
 pub fn python_exception(error: impl Error) -> PyErr {
     let mut s = String::new();
     let mut error: &dyn Error = &error;
@@ -25,7 +29,10 @@ pub fn python_exception(error: impl Error) -> PyErr {
         write!(&mut s, ": {}", error).unwrap();
     }
 
-    S3Exception::new_err(s)
+    let py_err = S3Exception::new_err(s);
+    let py_err_str = format!("{}", py_err);
+    log_error(&py_err_str);
+    py_err
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description
Added printing of errors for more visibility in case of exceptions during multipart uploads. A customer using s3connector for PyTorch for saving checkpoints reported an issue where they only receive a generic ```s3torchconnectorclient._mountpoint_s3_client.S3Exception: Client error: Request canceled``` without detailed visibility into the actual error encountered during multipart uploads.

Upon investigation, we discovered that the issue stems from how exceptions from the mountpoint code are being mapped  to Python exceptions. Currently, the implementation only exposes the final exception encountered during the multipart upload, effectively masking any errors that occur with individual parts of the upload.

To enhance visibility and provide more comprehensive error information, we should capture and print errors for each part of the multipart upload. This way, all errors encountered during the upload process will be visible, allowing for better diagnosis and resolution of issues.
## Additional context
NA

- [NA] I have updated the CHANGELOG or README if appropriate

## Related items
NA

## Testing
Ran the example code for lightning -  checkpoint_manual_save.py
Output was
```
14.6 M    Total params
58.543    Total estimated model params size (MB)
60        Modules in train mode
0         Modules in eval mode
/Users/rajdchak/PycharmProjects/pytorchrelease/fork-s3-connector-for-pytorch/virtual-env/lib/python3.9/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:419: Consider setting `persistent_workers=True` in 'train_dataloader' to speed up the dataloader worker initialization.
Epoch 0:   0%|                                                                                                                                                | 3/59674 [00:00<2:32:43,  6.51it/s, v_num=2]`Trainer.fit` stopped: `max_steps=3` reached.
Epoch 0:   0%|                                                                                                                                                | 3/59674 [00:00<2:32:48,  6.51it/s, v_num=2]
ERROR: S3Exception: Client error: Unknown CRT error: CRT error 14366: aws-c-s3: AWS_ERROR_S3_REQUEST_HAS_COMPLETED, Request has already completed, action cannot be performed.
ERROR: S3Exception: Client error: Request canceled
ERROR: S3Exception: Client error: Request canceled
Traceback (most recent call last):
  File "/Users/rajdchak/PycharmProjects/pytorchrelease/fork-s3-connector-for-pytorch/examples/lightning/checkpoint_manual_save.py", line 34, in <module>
    main(os.getenv("REGION"), os.getenv("CHECKPOINT_PATH"))
  File "/Users/rajdchak/PycharmProjects/pytorchrelease/fork-s3-connector-for-pytorch/examples/lightning/checkpoint_manual_save.py", line 28, in main
    trainer.save_checkpoint(checkpoint_path)
  File "/Users/rajdchak/PycharmProjects/pytorchrelease/fork-s3-connector-for-pytorch/virtual-env/lib/python3.9/site-packages/lightning/pytorch/trainer/trainer.py", line 1365, in save_checkpoint
    self.strategy.save_checkpoint(checkpoint, filepath, storage_options=storage_options)
  File "/Users/rajdchak/PycharmProjects/pytorchrelease/fork-s3-connector-for-pytorch/virtual-env/lib/python3.9/site-packages/lightning/pytorch/strategies/strategy.py", line 490, in save_checkpoint
    self.checkpoint_io.save_checkpoint(checkpoint, filepath, storage_options=storage_options)
  File "/Users/rajdchak/PycharmProjects/pytorchrelease/fork-s3-connector-for-pytorch/s3torchconnector/src/s3torchconnector/lightning/s3_lightning_checkpoint.py", line 51, in save_checkpoint
    torch.save(checkpoint, s3writer)
  File "/Users/rajdchak/PycharmProjects/pytorchrelease/fork-s3-connector-for-pytorch/s3torchconnector/src/s3torchconnector/s3writer.py", line 22, in __exit__
    self.close()
  File "/Users/rajdchak/PycharmProjects/pytorchrelease/fork-s3-connector-for-pytorch/s3torchconnector/src/s3torchconnector/s3writer.py", line 52, in close
    self.stream.close()
s3torchconnectorclient._mountpoint_s3_client.S3Exception: Client error: Request canceled

```
Thus we get the information about the all the errors.
```
ERROR: S3Exception: Client error: Unknown CRT error: CRT error 14366: aws-c-s3: AWS_ERROR_S3_REQUEST_HAS_COMPLETED, Request has already completed, action cannot be performed.
ERROR: S3Exception: Client error: Request canceled
ERROR: S3Exception: Client error: Request canceled
```
--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
