### PR TITLE
EmbarkStudios/cargo-deny-action from 1 to 2 and Add version = 2 in deny.toml

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -31,7 +31,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo deny
-        uses: EmbarkStudios/cargo-deny-action@v1
+        uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check ${{ matrix.checks }}
           manifest-path: s3torchconnectorclient/Cargo.toml

--- a/s3torchconnectorclient/deny.toml
+++ b/s3torchconnectorclient/deny.toml
@@ -26,7 +26,4 @@ license-files = [
 ]
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "warn"
-notice = "deny"
+version = 2


### PR DESCRIPTION
EmbarkStudios/cargo-deny-action from 1 to 2 and Add version = 2 in deny.toml
## Description
Dependabot suggested to update the version of EmbarkStudios/cargo-deny-action from 1 to 2 , however integration tests where failing due to some deprecated keys in deny.toml. Added mitigation for the same.

## Additional context
NA


- [NA] I have updated the CHANGELOG or README if appropriate

## Related items
NA
## Testing
Ran unit and integration tests locally.
--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
