### PR TITLE
Migrated actions/download-artifact and actions/upload-artifact from v3 to v4. 

### DIFF
--- a/.github/workflows/generate_third_party_licenses.yml
+++ b/.github/workflows/generate_third_party_licenses.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Generate NOTICE_DEFAULT file
         id: ort-action
         # https://github.com/oss-review-toolkit/ort-ci-github-action/issues/28
-        uses: oss-review-toolkit/ort-ci-github-action@7f23c1f8d169dad430e41df223d3b8409c7a156e
+        uses: oss-review-toolkit/ort-ci-github-action@81698a977ebcf51bb3d6ef5c6a04220cf60d3bde
         with:
           ort-cli-report-args: -f PlainTextTemplate
           run: >

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,11 +59,7 @@ jobs:
           role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
           aws-region: ${{ vars.S3_REGION }}
 
-      # Downloading artifacts that were created from action/upload-artifact@v3 and below are not supported.
-      # https://github.com/actions/download-artifact
-      # These actions should remain @v3 for now, ignore dependabot proposed upgrade.
-      # https://github.com/actions/upload-artifact/issues/478
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ needs.generate_third_party_licenses.outputs.artifact_name }}
 
@@ -106,10 +102,10 @@ jobs:
           2>&1
         shell: bash
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: "./wheelhouse/*.whl"
-          name: wheels
+          name: wheels-${{ matrix.python }}-${{ matrix.builder.kind }}_${{ matrix.builder.arch }}
 
   build_source_wheels:
     name: Build source wheels for ${{ matrix.build_target }}
@@ -124,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ needs.generate_third_party_licenses.outputs.artifact_name }}
 
@@ -141,7 +137,7 @@ jobs:
           python -m pip install build
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: "./${{ matrix.build_target }}/dist/*"
-          name: wheels
+          name: wheels-${{ matrix.build_target }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -141,3 +141,15 @@ jobs:
         with:
           path: "./${{ matrix.build_target }}/dist/*"
           name: wheels-${{ matrix.build_target }}
+  merge:
+    name: Merge the wheels
+    runs-on: ubuntu-latest
+    needs:
+      - build_wheels
+      - build_source_wheels
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+           name: wheels
+           pattern: wheels-*


### PR DESCRIPTION
## Description
Migrated actions/download-artifact and actions/upload-artifact from v3 to v4. 
1. In v3, artifacts are mutable so it's possible to write workflow scenarios where multiple jobs upload to the same artifact. In v4, artifacts are immutable (unless deleted). So each of the uploaded artifacts must have a different name. Added mitigation for the same in this PR.

2. Added a new job in wheels.yml to merge all the wheels generated by the jobs.

## Additional context
https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md


- [NA] I have updated the CHANGELOG or README if appropriate

## Related items
https://github.com/awslabs/s3-connector-for-pytorch/pull/209

## Testing

Ran all unit and integration tests. Also generated wheels and checked https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/10923188484.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
