### PR TITLE
fix: restrain PyTorch version to below 2.5

### DIFF
--- a/s3torchbenchmarking/pyproject.toml
+++ b/s3torchbenchmarking/pyproject.toml
@@ -9,8 +9,9 @@ description = "Tools to run and compare benchmarks against various PyTorch conne
 requires-python = ">=3.8,<3.13"
 readme = "README.md"
 dependencies = [
-    #TODO: Remove torch != 2.3.0 restriction when https://github.com/pytorch/data/issues/1244 is fixed
-    "torch >= 2.0.1, != 2.3.0",
+    # TODO: remove "!= 2.3.0" restriction once https://github.com/pytorch/data/issues/1244 is fixed
+    # TODO: remove "< 2.5" restriction once https://github.com/pytorch/pytorch/issues/138333 is fixed
+    "torch >= 2.0.1, != 2.3.0, < 2.5",
     "lightning >= 2.0",
     "s3torchconnector",
     "hydra-core",

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "torch >= 2.0.1, < 2.5", # remove "< 2.5" restriction once https://github.com/pytorch/pytorch/issues/138333 is addressed
+    "torch >= 2.0.1, < 2.5", # TODO: remove "< 2.5" restriction once https://github.com/pytorch/pytorch/issues/138333 is fixed
     "s3torchconnectorclient >= 1.2.6",
 ]
 

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "torch >= 2.0.1, < 2.5",
+    "torch >= 2.0.1, < 2.5", # remove "< 2.5" restriction once https://github.com/pytorch/pytorch/issues/138333 is addressed
     "s3torchconnectorclient >= 1.2.6",
 ]
 

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "torch >= 2.0.1",
+    "torch >= 2.0.1, < 2.5",
     "s3torchconnectorclient >= 1.2.6",
 ]
 


### PR DESCRIPTION
Restrain PyTorch version to below 2.5, since the latter creates some problem in our CI and wheels building.

See also: https://github.com/pytorch/pytorch/issues/138333

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
