### PR TITLE
Bump s3-connector-for-pytorch versions to v1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.7 (October 29, 2024)
+
+### New features
+* Add support for CRT retries (awslabs/mountpoint-s3#1069).
+* Add support for `CopyObject` API (#242).
+
 ## v1.2.6 (October 9, 2024)
 
 ### New features

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "s3torchconnector"
-version = "1.2.6"
+version = "1.2.7"
 description = "S3 connector integration for PyTorch"
 requires-python = ">=3.8,<3.13"
 readme = "README.md"
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "torch >= 2.0.1, < 2.5", # TODO: remove "< 2.5" restriction once https://github.com/pytorch/pytorch/issues/138333 is fixed
-    "s3torchconnectorclient >= 1.2.6",
+    "s3torchconnectorclient >= 1.2.7",
 ]
 
 [project.optional-dependencies]

--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -1105,7 +1105,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "s3torchconnectorclient"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "built",
  "futures",

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3torchconnectorclient"
-version = "1.2.6"
+version = "1.2.7"
 edition = "2021"
 publish = false
 license = "BSD-3-Clause"

--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "s3torchconnectorclient"
-version = "1.2.6"
+version = "1.2.7"
 description = "Internal S3 client implementation for s3torchconnector"
 requires-python = ">=3.8,<3.13"
 readme = "README.md"


### PR DESCRIPTION
Bump s3-connector-for-pytorch versions to v1.2.7.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
