### PR TITLE
ci: bump "actions/cache/*" version from v3 to v4

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Restore Cargo cache
         id: restore-cargo-cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -107,7 +107,7 @@ jobs:
           pytest s3torchconnectorclient/python/tst/integration -n auto
 
       - name: Save Cargo cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: inputs.environment != 'integration-tests'
         with:
           path: |


### PR DESCRIPTION
v3 runs on a deprecated Node.js version, and GitHub warns us to move on a new version (v4).

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
