### PR TITLE
feat(dcp): add benchmark capabilities for DCP

### DIFF
--- a/s3torchbenchmarking/pyproject.toml
+++ b/s3torchbenchmarking/pyproject.toml
@@ -27,9 +27,18 @@ dependencies = [
     "click",
     "omegaconf",
     "accelerate",
+    "jinja2",
 ]
-optional-dependencies = { test = ["pytest"] }
-scripts = { s3torch-benchmark = "s3torchbenchmarking.benchmark:run_experiment", s3torch-datagen = "s3torchbenchmarking.datagen:synthesize_dataset" }
+
+[project.optional-dependencies]
+test = [
+    "pytest"
+]
+
+[project.scripts]
+s3torch-benchmark = "s3torchbenchmarking.benchmark:run_experiment"
+s3torch-datagen = "s3torchbenchmarking.datagen:synthesize_dataset"
+s3torch-benchmark-dcp = "s3torchbenchmarking.dcp.benchmark:run_benchmark"
 
 [tool.setuptools.packages]
 # Pure Python packages/modules and configuration files

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/README.md
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/README.md
@@ -1,0 +1,134 @@
+## PyTorch's Distributed Checkpoint (DCP) benchmarks
+
+The `dcp` Python package holds all the logic to execute benchmarks for [PyTorch's Distributed Checkpointing][DCP]
+feature against the `s3torchconnector` library.
+
+### Purpose
+
+The benchmarks are designed to test the "save" and "load" mechanisms of PyTorch
+(`torch.distributed.checkpoint[save,load]`), and compare the s3torchconnector library performance vs. other libraries,
+like fsspec.
+
+### Usage
+
+> [!IMPORTANT]
+> The benchmarks are designed to be run on a EC2 instance.
+
+Install the `s3torchbenchmarking` package with `pip` (see the [root README](../../../README.md) for instructions); once
+installed, the DCP benchmarks can be run with:
+
+```shell
+$ s3torch-benchmark-dcp
+```
+
+The command can be executed from any directory; it will create a `./multirun/` directory (at the location of execution),
+and store all benchmark results there.
+
+#### Potential caveats
+
+While installing the package, one may run into an error like:
+
+```
+"TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'"
+```
+
+This error can be addressed by running:
+
+```shell
+$ pip install "setuptools<71"
+```
+
+### Configuration
+
+The benchmark runs can be customized using the [`config.yaml`](config.yaml) file. This section outlines the key
+configuration options and their impacts.
+
+#### Configuration Requirements
+
+All keys in the `config.yaml` file must be defined for a run to execute successfully.
+
+#### Key Configuration Options
+
+`epochs`
+
+- Specifies the number of iterations for the "save" and "load" operations.
+- Note: This does not affect model training, as no actual training occurs in these benchmarks.
+
+`path`
+
+- Designates the directory for benchmark operations.
+- If the specified directory doesn't exist, it will be created automatically.
+- For optimal performance using an SSD filesystem, refer to the [`prepare_nvme.sh`](../../../utils/prepare_nvme.sh)
+  script.
+
+`hydra.sweeper.params`
+
+This section allows for multiple benchmark configurations:
+
+- The benchmark will run sequential jobs for each combination of the specified parameters.
+- Available options include:
+    - `+model`: Choose from pre-trained models listed in [`models.py`](models.py).
+    - `+backend`: Select `nccl`, `gloo`, or both.
+    - `+world_size`: Defines the number of processes. Note: Values exceeding the node's capacity will be automatically
+      capped.
+    - `+checkpoint.storage`: Choose `s3`, `disk`, or both.
+
+#### Example Configuration
+
+```yaml
+s3:
+  region: eu-west-1
+  uri: s3://my-benchmark-bucket
+epochs: 3
+path: nvme
+
+hydra:
+  mode: MULTIRUN
+  sweeper:
+    params:
+      +model: small,medium
+      +backend: nccl,gloo
+      +world_size: 2,4
+      +thread_count: 1
+      +checkpoint.storage: s3,disk
+```
+
+This configuration will run benchmarks for all combinations of the specified models, backends, world sizes, and storage
+options, totaling 16 (2\*2\*2\*1\*2) different benchmark scenarios.
+
+### Important notes
+
+- The benchmarks may take some time to complete, depending on the hardware and network configuration.
+- For optimal results, it is recommended to run the benchmarks on a dedicated EC2 instance without other
+  resource-intensive processes.
+- When specifying an S3 bucket in the `config.yaml` file, make sure that 1/ the bucket already exists in the specified
+  region, and 2/ the EC2 user/role used has write-permissions to it.
+
+### Results
+
+The benchmark results are organized in the following structure:
+
+```shell
+multirun/
+└── YYYY-MM-DD
+    └── HH-MM-SS
+        ├── 0
+        │   ├── benchmark.log
+        │   └── results_small_nccl_2_2_s3.json
+        ├── 1
+        │   ├── benchmark.log
+        │   └── results_small_nccl_2_2_disk.json
+        ├── 2
+        │   ├── benchmark.log
+        │   └── results_small_nccl_4_2_s3.json
+        ├── 3
+        │   ├── benchmark.log
+        │   └── results_small_nccl_4_2_disk.json
+        └── multirun.yaml
+```
+
+Each run creates a new subdirectory with a timestamp (e.g., `2024-11-11/10-21-16`). The `./multirun/` directory
+structure is managed by [Hydra](https://hydra.cc/), the underlying configuration framework.
+
+
+[DCP]: https://pytorch.org/docs/stable/distributed.checkpoint.html

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/__init__.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/benchmark.py
@@ -1,0 +1,148 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+import logging
+import os
+import random
+import string
+from os import PathLike
+from pathlib import Path
+from time import perf_counter
+from typing import Union
+
+import hydra
+import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig
+from torch import multiprocessing
+from torch.distributed.checkpoint import FileSystemWriter
+from torch.nn import Module
+from torch.nn.parallel import DistributedDataParallel
+
+from s3torchbenchmarking.benchmark_utils import ResourceMonitor
+from s3torchbenchmarking.dcp.models import get_benchmark_model_from_size
+from s3torchbenchmarking.dcp.results import save_results
+from s3torchbenchmarking.dcp.distribution import Distribution
+from s3torchconnector.dcp import S3StorageWriter
+
+logger = logging.getLogger(__name__)
+
+
+@hydra.main(version_base=None, config_path=".", config_name="config")
+def run_benchmark(cfg: DictConfig):
+    """DCP benchmark entry point."""
+    logger.info("Saving results to: %s", HydraConfig.get().runtime.output_dir)
+
+    benchmark_model = get_benchmark_model_from_size(cfg.model)
+    world_size = validate_world_size(cfg.world_size)
+
+    # For every run, use a randomized suffix (for either S3 or local storage).
+    suffix = "".join(random.choices(string.ascii_letters, k=7))
+
+    storage_writer = get_writer(
+        region=cfg.s3.region,
+        path=Path(cfg.path) / suffix,
+        s3_uri=build_checkpoint_uri(cfg.s3.uri, suffix),
+        thread_count=cfg.thread_count,
+        storage=cfg.checkpoint.storage,
+    )
+
+    save_times = Distribution()
+    with ResourceMonitor() as monitor:
+        for epoch in range(cfg.epochs):
+            logger.info("Running epoch #%i / %i...", epoch + 1, cfg.epochs)
+            start_time = perf_counter()
+            multiprocessing.spawn(
+                run,
+                args=(
+                    cfg.backend,
+                    benchmark_model.pre_trained_model,
+                    world_size,
+                    storage_writer,
+                ),
+                nprocs=world_size,
+                join=True,
+            )
+            elapsed_time = perf_counter() - start_time
+            save_times.append(elapsed_time)
+
+    save_results(cfg, benchmark_model, save_times, monitor)
+
+
+def validate_world_size(world_size: int) -> int:
+    """Enforce `world_size` to be within the current node's capacity."""
+
+    # FIXME: only works when the backend is "nccl"; what about "gloo" and CPUs?
+    device_count = torch.cuda.device_count()
+    if world_size > device_count:
+        logger.warning(
+            "Received a `world_size` of %i, while only %i are available: decreasing to %i",
+            world_size,
+            device_count,
+            device_count,
+        )
+        return device_count
+    return world_size
+
+
+def get_writer(
+    region: str,
+    path: Union[str, PathLike],
+    s3_uri: str,
+    thread_count: int,
+    storage: str,
+) -> FileSystemWriter:
+    if storage == "disk":
+        return dcp.FileSystemWriter(path, thread_count=thread_count)
+    elif storage == "s3":
+        return S3StorageWriter(
+            region,
+            s3_uri,
+            thread_count=thread_count,
+        )
+    raise ValueError(f"Storage writer {storage} not supported")
+
+
+def build_checkpoint_uri(s3_uri: str, suffix: str) -> str:
+    suffix = suffix.lstrip("/")
+    return s3_uri + suffix if s3_uri.endswith("/") else s3_uri + "/" + suffix
+
+
+def setup(backend: str, world_size: int, rank: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "12355"
+    dist.init_process_group(backend=backend, world_size=world_size, rank=rank)
+
+
+def run(
+    rank: int,  # needs to be passed first (provided by `multiprocessing.spawn` automatically)
+    backend: str,
+    model: Module,
+    world_size: int,
+    storage_writer: FileSystemWriter,
+) -> None:
+    logger.info("Running on rank %i...", rank)
+
+    torch.cuda.set_device(rank)
+    setup(backend=backend, world_size=world_size, rank=rank)
+    rank = dist.get_rank()
+    device_id = rank % torch.cuda.device_count()
+
+    logger.debug("Device ID: %i", device_id)
+
+    model.to(device_id)
+    wrapped_model = DistributedDataParallel(model, device_ids=[device_id])
+
+    logger.info("Saving checkpoint on rank %i...", rank)
+    start_time = perf_counter()
+    dcp.save(
+        wrapped_model.state_dict(),
+        storage_writer=storage_writer,
+    )
+    elapsed_time = perf_counter() - start_time
+    logger.debug("DCP save time: %f s", elapsed_time)
+    logger.info("Checkpoint successfully saved on rank %i", rank)
+
+    dist.destroy_process_group()

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/config.yaml
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/config.yaml
@@ -1,0 +1,16 @@
+s3:
+  region: ???
+  uri: ???
+epochs: 4
+path: nvme # only used when `checkpoint.storage` contains `disk`, ignored for `s3`
+
+# https://hydra.cc/docs/tutorials/basic/running_your_app/multi-run/#sweeper
+hydra:
+  mode: MULTIRUN
+  sweeper:
+    params:
+      +model: small,medium
+      +backend: nccl,gloo
+      +world_size: 1,2,4,8 # == total number of workers
+      +thread_count: 1,2,4,8
+      +checkpoint.storage: s3,disk

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/distribution.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/distribution.py
@@ -1,0 +1,42 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+from typing import TypedDict
+
+import numpy as np
+
+
+class Statistics(TypedDict, total=False):
+    n: int  # number of elements in the distribution
+    unit: str
+    value: float  # when the number of elements is one, `value` will contain it
+    mean: float
+    min: float
+    p50: float
+    p75: float
+    p90: float
+    max: float
+
+
+class Distribution(list):
+    """Extension of :obj:`list`, adding statistics dump (min, max, median, etc.)."""
+
+    def dump(self, unit: str) -> Statistics:
+        if not self:
+            return {}
+        if len(self) == 1:
+            return {
+                "n": 1,
+                "unit": unit,
+                "value": self[0],
+            }
+        return {
+            "n": len(self),
+            "unit": unit,
+            "mean": np.nanmean(self),  # `nan*` methods ignore NaN values
+            "min": np.nanmin(self),
+            "p50": np.nanmedian(self),
+            "p75": np.nanpercentile(self, 75),
+            "p90": np.nanpercentile(self, 90),
+            "max": np.nanmax(self),
+        }

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/models.py
@@ -1,0 +1,60 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+from functools import cached_property
+from typing import Callable
+
+from torch.nn import Module
+from transformers import AutoModelForSeq2SeqLM, ViTModel, CLIPModel
+
+
+class BenchmarkModel:
+    """Utility class around a :class:`torch.nn.Module`, with an additional metadata layer."""
+
+    def __init__(self, loader: Callable, name: str):
+        self._loader = loader
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @cached_property
+    def pre_trained_model(self) -> Module:
+        return self._loader(self._name)
+
+    @cached_property
+    def size(self) -> float:
+        """Compute a model size (in bytes).
+
+        Sourced from https://discuss.pytorch.org/t/finding-model-size/130275/2.
+        """
+        param_size = 0
+        for param in self.pre_trained_model.parameters():
+            param_size += param.nelement() * param.element_size()
+        buffer_size = 0
+        for buffer in self.pre_trained_model.buffers():
+            buffer_size += buffer.nelement() * buffer.element_size()
+        return param_size + buffer_size
+
+
+SIZE_TO_MODEL = {
+    # ~350 MB model
+    "small": BenchmarkModel(
+        ViTModel.from_pretrained, "google/vit-base-patch16-224-in21k"
+    ),  # ~1.7 GB model
+    "small-2": BenchmarkModel(
+        CLIPModel.from_pretrained, "openai/clip-vit-large-patch14"
+    ),  # ~12 GB model
+    "medium": BenchmarkModel(
+        AutoModelForSeq2SeqLM.from_pretrained, "bigscience/T0_3B"
+    ),  # ~45 GB model
+    "large": BenchmarkModel(AutoModelForSeq2SeqLM.from_pretrained, "bigscience/T0pp"),
+}
+
+
+def get_benchmark_model_from_size(size: str) -> BenchmarkModel:
+    """Select a model for benchmarking."""
+    if size not in SIZE_TO_MODEL:
+        raise ValueError(f"Size {size} for model is unexpected")
+    return SIZE_TO_MODEL[size]

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/results.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/results.py
@@ -1,0 +1,115 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+import json
+import logging
+import re
+import subprocess
+import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import TypedDict, Union, Any
+
+import torch
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig, OmegaConf
+
+from s3torchbenchmarking.benchmark_utils import ResourceMonitor
+from s3torchbenchmarking.dcp.distribution import Distribution, Statistics
+from s3torchbenchmarking.dcp.models import BenchmarkModel
+
+logger = logging.getLogger(__name__)
+
+
+class EC2Metadata(TypedDict):
+    instance_type: str
+    placement: str
+
+
+class Metadata(TypedDict):
+    python_version: str
+    pytorch_version: str
+    hydra_version: str
+    ec2_metadata: Union[EC2Metadata, None]
+    model_name: str
+    model_size: float
+
+
+class Data(TypedDict):
+    throughput: Statistics
+    utilization: dict
+    save_times: Statistics
+
+
+class Results(TypedDict):
+    metadata: Metadata
+    config: Any
+    data: Data
+
+
+def save_results(
+    cfg: DictConfig,
+    model: BenchmarkModel,
+    save_times: Distribution,
+    monitor: ResourceMonitor,
+):
+    """Save a Hydra job's results to a local JSON file."""
+
+    results: Results = {
+        "metadata": {
+            "python_version": sys.version,
+            "pytorch_version": torch.__version__,
+            "hydra_version": HydraConfig.get().runtime.version,
+            "ec2_metadata": get_ec2_metadata(),
+            "model_name": model.name,
+            "model_size": model.size,
+        },
+        "config": OmegaConf.to_container(cfg),
+        "data": {
+            "throughput": to_throughput(save_times, model.size).dump(unit="B/s"),
+            "utilization": {k: v.summarize() for k, v in monitor.resource_data.items()},
+            "save_times": save_times.dump(unit="s"),
+        },
+    }
+
+    # `tasks` will contain the list of Hydra overrides (defined in the config.yaml file) in the form `"param=value"`;
+    # this helps identify result files uniquely just by their filenames.
+    # E.g.: `["foo=4", "bar=small", "baz=1"]` -> `suffix == "4_small_1"`.
+    tasks = HydraConfig.get().overrides.task
+    suffix = "_".join([task.split("=")[-1] for task in tasks])
+
+    # Save the results in the corresponding Hydra job directory (e.g., multirun/2024-11-08/15-47-08/0/<filename>.json).
+    results_filename = f"results{'_' + suffix if suffix else ''}.json"
+    results_dir = HydraConfig.get().runtime.output_dir
+    results_path = Path(results_dir, results_filename)
+
+    logger.info("Saving results to %s...", results_path)
+    with open(results_path, "w") as f:
+        json.dump(results, f, ensure_ascii=False, indent=4)
+    logger.info("Results saved successfully")
+
+
+def to_throughput(save_times: Distribution, model_size: float) -> Distribution:
+    """Compute throughput from save times, in B/s."""
+    return Distribution(map(lambda x: model_size / x, save_times))
+
+
+@lru_cache
+def get_ec2_metadata() -> Union[EC2Metadata, None]:
+    """Get some EC2 metadata by running the `/opt/aws/bin/ec2-metadata` command.
+
+    The command's output is a single string of text, in a JSON-like format (_but not quite JSON_): hence, its content
+    is parsed using regex.
+
+    The function's call is cached, so we don't execute the command multiple times per runs.
+    """
+    result = subprocess.run(
+        "/opt/aws/bin/ec2-metadata", capture_output=True, text=True, timeout=5
+    )
+    if result.returncode == 0:
+        metadata = result.stdout
+        instance_type = re.search("instance-type: (.*)", metadata).group(1)
+        placement = re.search("placement: (.*)", metadata).group(1)
+        if instance_type and placement:
+            return {"instance_type": instance_type, "placement": placement}
+    return None

--- a/s3torchconnector/tst/unit/dcp/test_s3_file_system.py
+++ b/s3torchconnector/tst/unit/dcp/test_s3_file_system.py
@@ -1,10 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 
-import os
-from pathlib import Path
-from typing import Union
-
 import pytest
 
 from s3torchconnector._s3client import MockS3Client
@@ -15,19 +11,25 @@ TEST_REGION = "eu-east-1"
 TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key.txt"
 TEST_DATA = b"test data\n"
-TEST_PATH = f"s3://{TEST_BUCKET}/{TEST_KEY}"
+
+_build_s3_uri = lambda bucket, key: f"s3://{bucket}/{key}"
+
+
+# TODO: transform all "path"s to actual S3 URIs.
 
 
 def test_create_stream():
     mock_client = MockS3Client(TEST_REGION, TEST_BUCKET)
     s3fs = S3FileSystem(TEST_REGION, mock_client)
 
-    with s3fs.create_stream(TEST_PATH, "wb") as writer:
+    path = _build_s3_uri(TEST_BUCKET, TEST_KEY)
+
+    with s3fs.create_stream(path, "wb") as writer:
         writer.write(TEST_DATA)
 
-    assert s3fs.exists(TEST_PATH)
+    assert s3fs.exists(path)
 
-    with s3fs.create_stream(TEST_PATH, "rb") as reader:
+    with s3fs.create_stream(path, "rb") as reader:
         assert reader.read() == TEST_DATA
 
 
@@ -35,48 +37,46 @@ def test_create_stream_raise_when_mode_is_unknown():
     mock_client = MockS3Client(TEST_REGION, TEST_BUCKET)
     s3fs = S3FileSystem(TEST_REGION, mock_client)
 
+    path = _build_s3_uri(TEST_BUCKET, TEST_KEY)
+
     with pytest.raises(ValueError) as excinfo:
-        with s3fs.create_stream(TEST_PATH, "foobar"):
+        with s3fs.create_stream(path, "foobar"):
             pass
 
     assert (
         str(excinfo.value)
-        == "Invalid mode='foobar' mode argument: create_stream only supports rb (read mode) & wb (write mode)"
+        == 'Invalid mode=\'foobar\' argument: `create_stream` only supports "rb" (read) or "wb" (write) modes'
     )
 
 
-@pytest.mark.parametrize(
-    "path,suffix,expected",
-    [
-        ("str_path", "suffix", "str_path/suffix"),
-        (Path("path_path"), "suffix", "path_path/suffix"),
-    ],
-)
-def test_concat_path(path: Union[str, os.PathLike], suffix: str, expected: str):
+def test_concat_path():
     mock_client = MockS3Client(TEST_REGION, TEST_BUCKET)
     s3fs = S3FileSystem(TEST_REGION, mock_client)
 
-    assert s3fs.concat_path(path, suffix) == expected
+    path = _build_s3_uri(TEST_BUCKET, TEST_KEY)
+    suffix = "suffix"
+
+    assert s3fs.concat_path(path, suffix) == path + "/" + suffix
 
 
-@pytest.mark.parametrize("path", ["str_path", Path("path_path")])
-def test_init_path(path: Union[str, os.PathLike]):
+def test_init_path():
     mock_client = MockS3Client(TEST_REGION, TEST_BUCKET)
     s3fs = S3FileSystem(TEST_REGION, mock_client)
 
+    path = "s3://bucket/key"
     assert s3fs.init_path(path) == path
 
 
 def test_rename():
     src_key, src_data = ("src_key.txt", b"src data\n")
     dst_key = "dst_key.txt"
-    src_path = _build_s3_uri(TEST_BUCKET, src_key)
-    dst_path = _build_s3_uri(TEST_BUCKET, dst_key)
 
     mock_client = MockS3Client(TEST_REGION, TEST_BUCKET)
     mock_client.add_object(src_key, src_data)
     s3fs = S3FileSystem(TEST_REGION, mock_client)
 
+    src_path = _build_s3_uri(TEST_BUCKET, src_key)
+    dst_path = _build_s3_uri(TEST_BUCKET, dst_key)
     s3fs.rename(src_path, dst_path)
 
     assert s3fs.exists(src_path) is False
@@ -86,19 +86,20 @@ def test_rename():
 def test_rename_raises_when_buckets_are_different():
     src_key, src_data = ("src_key.txt", b"src data\n")
     dst_key = "dst_key"
-    src_path = _build_s3_uri(TEST_BUCKET, src_key)
-    dst_path = _build_s3_uri(TEST_BUCKET + "-another", dst_key)
 
     mock_client = MockS3Client(TEST_REGION, TEST_BUCKET)
     mock_client.add_object(src_key, src_data)
     s3fs = S3FileSystem(TEST_REGION, mock_client)
+
+    src_path = _build_s3_uri(TEST_BUCKET, src_key)
+    dst_path = _build_s3_uri(TEST_BUCKET + "-another", dst_key)
 
     with pytest.raises(ValueError) as excinfo:
         s3fs.rename(src_path, dst_path)
 
     assert (
         str(excinfo.value)
-        == "Source and destination buckets cannot be different (rename does not support cross-buckets operations)"
+        == "Source and destination buckets cannot be different (`rename` does not support cross-buckets operations)"
     )
 
 
@@ -134,7 +135,7 @@ def test_exists_true_when_key_exists():
     mock_client.add_object(TEST_KEY, TEST_DATA)
     s3fs = S3FileSystem(TEST_REGION, mock_client)
 
-    assert s3fs.exists(TEST_PATH) is True
+    assert s3fs.exists(_build_s3_uri(TEST_BUCKET, TEST_KEY)) is True
 
 
 def test_exists_false_when_key_does_not_exist():
@@ -154,7 +155,7 @@ def test_exists_raise_when_underlying_exception_is_unexpected(exception):
 
     mock_client = MockS3Client(TEST_REGION, TEST_BUCKET)
 
-    def raise_s3_exception(bucket, key):
+    def raise_s3_exception(_, __):
         raise exception
 
     mock_client.head_object = raise_s3_exception
@@ -172,21 +173,20 @@ def test_rm_file():
     mock_client.add_object(TEST_KEY, TEST_DATA)
     s3fs = S3FileSystem(TEST_REGION, mock_client)
 
-    assert s3fs.exists(TEST_PATH) is True
+    path = _build_s3_uri(TEST_BUCKET, TEST_KEY)
 
-    s3fs.rm_file(TEST_PATH)
+    assert s3fs.exists(path) is True
 
-    assert s3fs.exists(TEST_PATH) is False
+    s3fs.rm_file(path)
+
+    assert s3fs.exists(path) is False
 
 
 def test_validate_checkpoint_id():
-    assert S3FileSystem.validate_checkpoint_id(TEST_PATH) is True
+    path = _build_s3_uri(TEST_BUCKET, TEST_KEY)
+    assert S3FileSystem.validate_checkpoint_id(path) is True
 
 
 @pytest.mark.parametrize("checkpoint_id", ["foobar", "s3:///"])
 def test_validate_checkpoint_id_returns_false_when_path_is_invalid(checkpoint_id):
     assert S3FileSystem.validate_checkpoint_id(checkpoint_id) is False
-
-
-def _build_s3_uri(bucket: str, key: str) -> str:
-    return f"s3://{bucket}/{key}"


### PR DESCRIPTION
Create a dedicated `dcp` Python package within `s3torchbenchmarking`, to run benchmarks against fsspec.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
