### PR TITLE
Extend aws role timeout

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
           aws-region: ${{ vars.S3_REGION }}
+          # extend role time out to 2 hours
+          role-duration-seconds: 7200
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Description
macOS wheel builds were failing due to an expiration timeout of the IAM role used for running integration tests. The builds were exceeding the one-hour limit. This change extends the timeout from one hour to two hours, allowing sufficient time for the builds to complete successfully.

- [X] I have updated the CHANGELOG or README if appropriate

## Testing
Successful wheel build run https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/11919193637/job/33218510050

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
