### PR TITLE
fix(dcp): address bug in DCP + CPU benchmarks (gloo)

### DIFF
--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/README.md
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/README.md
@@ -16,8 +16,8 @@ These benchmarks are designed to:
 > [!IMPORTANT]
 > The benchmarks are designed to be run on a EC2 instance.
 
-Install the `s3torchbenchmarking` package with `pip` (see the [root README](../../../README.md) for instructions); once
-installed, the DCP benchmarks can be run with:
+Install the `s3torchbenchmarking` package with `pip` (see the [root README](../../../README.md) for instructions),
+along with the `s3torchconnector[dcp]` extra; once installed, the DCP benchmarks can be run with:
 
 ```shell
 $ s3torch-benchmark-dcp -cd conf -cn dcp
@@ -32,13 +32,28 @@ The command must be executed from the package's root, where it can read from the
 
 #### Potential caveats
 
-If you encounter the following error during installation:
+If you encounter the following errors during installation, try the associated command:
+
+**Error**:
+
+```
+RuntimeError: Failed to import transformers.models.vit.modeling_vit because of the following error (look up to see its traceback):
+operator torchvision::nms does not exist
+```
+
+**Try**:
+
+```shell
+$ conda install -y pytorch torchvision torchaudio pytorch-cuda=12.4 -c pytorch -c nvidia
+```
+
+**Error**:
 
 ```
 TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
 ```
 
-Run this command to resolve it:
+**Try**:
 
 ```shell
 $ pip install "setuptools<71"

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/benchmark.py
@@ -109,12 +109,14 @@ def run(
     if cfg.backend == "nccl":
         device_id = rank % torch.cuda.device_count()
         torch.cuda.set_device(device_id)
+        model.to(device_id)
+        model = DistributedDataParallel(model, device_ids=[device_id])
     else:
         device_id = rank % torch.cpu.device_count()
         torch.cpu.set_device(device_id)
+        model.to(device=torch.device("cpu"))
+        model = DistributedDataParallel(model)
 
-    model.to(device_id)
-    model = DistributedDataParallel(model, device_ids=[device_id])
     state_dict = model.state_dict()
 
     begin_save = perf_counter()


### PR DESCRIPTION
Write `model.to(device=torch.device("cpu")` for gloo-based benchmarks instead of `model.to(device_id)`. Also, update DCP benchmarks README.md and add one extra caveat and its solution.

--------

By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
