### PR TITLE
Update slack action to explicitly provide webhook-type

### DIFF
--- a/.github/workflows/notify-comment.yml
+++ b/.github/workflows/notify-comment.yml
@@ -11,12 +11,11 @@ jobs:
       - name: Send notification to Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE_COMMENT }}
+          webhook-type: INCOMING_WEBHOOK
           payload: |
             {
               "action": "${{ github.event.action }}",
               "comment_url": "${{ github.event.comment.html_url }}",
               "content": ${{ toJSON(github.event.comment.body) }}
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE_COMMENT }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/notify-issue.yml
+++ b/.github/workflows/notify-issue.yml
@@ -11,11 +11,10 @@ jobs:
       - name: Send notification to Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
+          webhook-type: INCOMING_WEBHOOK
           payload: |
             {
               "action": "${{ github.event.action }}",
               "issue_url": "${{ github.event.issue.html_url }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -11,11 +11,10 @@ jobs:
       - name: Send notification to Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
+          webhook-type: INCOMING_WEBHOOK
           payload: |
             {
               "action": "${{ github.event.action }}",
               "url": "${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/notify-wheel-failure.yml
+++ b/.github/workflows/notify-wheel-failure.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Send notification to Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_WORKFLOW_FAILURE }}
+          webhook-type: INCOMING_WEBHOOK
           payload: |
             {
               "action": "${{ github.event.action }}",
@@ -21,6 +23,3 @@ jobs:
               "workflow_name": "${{ github.event.workflow.name }}",
               "workflow_run_url": "${{ github.event.workflow_run.html_url }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_WORKFLOW_FAILURE }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Description
slack-github-action introduced breaking changes in [v2.0.0](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0). It now requires to set `webhook-type`. Additionally, slack action allows to use `webhook` instead of `SLACK_WEBHOOK_URL`

- [x] I have updated the CHANGELOG or README if appropriate

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
