### PR TITLE
refactor(benchmarks): improve jobs and runs saves, add write to DynamoDB

### DIFF
--- a/s3torchbenchmarking/conf/dcp.yaml
+++ b/s3torchbenchmarking/conf/dcp.yaml
@@ -11,7 +11,11 @@ path: ???
 epochs: 4
 
 hydra:
+  job:
+    name: dcp
   mode: MULTIRUN
+  sweep:
+    dir: multirun/dcp/${now:%Y-%m-%d_%H-%M-%S}
   sweeper:
     params:
       +model: vit-base, T0_3B

--- a/s3torchbenchmarking/conf/lightning_checkpointing.yaml
+++ b/s3torchbenchmarking/conf/lightning_checkpointing.yaml
@@ -12,7 +12,11 @@ epochs: 5
 save_one_in: 1
 
 hydra:
+  job:
+    name: lightning_checkpointing
   mode: MULTIRUN
+  sweep:
+    dir: multirun/lightning/${now:%Y-%m-%d_%H-%M-%S}
   sweeper:
     params:
       +model: vit-base, whisper, clip-vit, T0_3B, T0pp

--- a/s3torchbenchmarking/pyproject.toml
+++ b/s3torchbenchmarking/pyproject.toml
@@ -25,9 +25,9 @@ dependencies = [
     "boto3",
     "prefixed",
     "click",
-    "omegaconf",
     "accelerate",
     "pandas",
+    "requests",
 ]
 
 [project.optional-dependencies]
@@ -38,9 +38,3 @@ test = [
 [project.scripts]
 s3torch-benchmark = "s3torchbenchmarking.benchmark:run_experiment"
 s3torch-datagen = "s3torchbenchmarking.datagen:synthesize_dataset"
-s3torch-benchmark-lightning = "s3torchbenchmarking.lightning_checkpointing.benchmark:run_benchmark"
-s3torch-benchmark-dcp = "s3torchbenchmarking.dcp.benchmark:run_benchmark"
-
-[tool.setuptools.packages]
-# Pure Python packages/modules and configuration files
-find = { where = ["src"] }

--- a/s3torchbenchmarking/src/s3torchbenchmarking/constants.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/constants.py
@@ -1,0 +1,40 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+from typing import TypedDict, Union, Any, List
+
+JOB_RESULTS_FILENAME = "job_results.json"
+RUN_FILENAME = "run.json"
+
+# URLs for EC2 metadata retrieval (IMDSv2)
+URL_IMDS_TOKEN = "http://169.254.169.254/latest/api/token"
+URL_IMDS_DOCUMENT = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+
+
+class Versions(TypedDict):
+    python: str
+    pytorch: str
+    hydra: str
+    s3torchconnector: str
+
+
+class EC2Metadata(TypedDict):
+    architecture: str
+    image_id: str
+    instance_type: str
+    region: str
+
+
+class Run(TypedDict):
+    """Information about a Hydra run.
+
+    Also, a :class:`Run` object will be inserted as-is in DynamoDB."""
+
+    run_id: str  # PK (Partition Key)
+    timestamp_utc: float  # SK (Sort Key)
+    scenario: str
+    versions: Versions
+    ec2_metadata: Union[EC2Metadata, None]
+    run_elapsed_time_s: float
+    number_of_jobs: int
+    all_job_results: List[Any]

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp/benchmark.py
@@ -19,10 +19,13 @@ from torch.distributed.checkpoint import FileSystemWriter
 from torch.nn import Module
 from torch.nn.parallel import DistributedDataParallel
 
+from s3torchbenchmarking.benchmark_utils import (
+    build_random_suffix,
+    build_checkpoint_uri,
+)
+from s3torchbenchmarking.job_results import save_job_results
+from s3torchbenchmarking.models import get_benchmark_model
 from s3torchconnector.dcp import S3StorageWriter
-from ..benchmark_utils import build_random_suffix, build_checkpoint_uri
-from ..job_results import save_job_results
-from ..models import get_benchmark_model
 
 Timestamps = Tuple[float, float]
 logger = logging.getLogger(__name__)
@@ -129,3 +132,7 @@ def run(
     save_timestamps.put((begin_process, end_save - (begin_save - begin_process)))
 
     dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/s3torchbenchmarking/src/s3torchbenchmarking/hydra_callback.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/hydra_callback.py
@@ -1,106 +1,139 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
 import json
 import logging
-import re
-import subprocess
 import sys
-from functools import lru_cache
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
 from pathlib import Path
 from time import perf_counter
-from typing import Any, List, TypedDict, Union, Optional
+from typing import Any, Union, Optional
 
+import boto3
+import requests
 import torch
+from botocore.exceptions import ClientError
 from hydra.experimental.callback import Callback
 from omegaconf import DictConfig
 
-_COLLATED_RESULTS_FILENAME = "collated_results.json"
+import s3torchconnector
+from s3torchbenchmarking.constants import (
+    JOB_RESULTS_FILENAME,
+    RUN_FILENAME,
+    Run,
+    EC2Metadata,
+    URL_IMDS_TOKEN,
+    URL_IMDS_DOCUMENT,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class EC2Metadata(TypedDict):
-    instance_type: str
-    placement: str
-
-
-class Metadata(TypedDict):
-    python_version: str
-    pytorch_version: str
-    hydra_version: str
-    ec2_metadata: Union[EC2Metadata, None]
-    run_elapsed_time_s: float
-    number_of_jobs: int
-
-
-class CollatedResults(TypedDict):
-    metadata: Metadata
-    results: List[Any]
-
-
 class ResultCollatingCallback(Callback):
+    """Hydra callback (https://hydra.cc/docs/experimental/callbacks/).
+
+    Defines some routines to execute when a benchmark run is finished: namely, to merge all job results
+    ("job_results.json" files) in one place ("run.json" file), augmented with some metadata.
+    """
+
     def __init__(self) -> None:
-        self._multirun_dir: Optional[Path] = None
+        self._multirun_path: Optional[Path] = None
         self._begin = 0
-        self._end = 0
 
     def on_multirun_start(self, config: DictConfig, **kwargs: Any) -> None:
         self._begin = perf_counter()
 
     def on_job_start(self, config: DictConfig, **kwargs: Any) -> None:
-        # Runtime variables like the output directory are not available in `on_multirun_end` is called, but are
-        # available in `on_job_start`, so we collect the path here and refer to it later.
-        if not self._multirun_dir:
-            # should be something like "./multirun/2024-11-08/15-47-08/"
-            self._multirun_dir = Path(config.hydra.runtime.output_dir).parent
+        if not self._multirun_path:
+            # Hydra variables like `hydra.runtime.output_dir` are not available inside :func:`on_multirun_end`, so we
+            # get the information here.
+            self._multirun_path = Path(config.hydra.runtime.output_dir).parent
 
     def on_multirun_end(self, config: DictConfig, **kwargs: Any) -> None:
-        self._end = perf_counter()
-        run_elapsed_time = self._end - self._begin
+        run_elapsed_time = perf_counter() - self._begin
+        run = self._build_run(config, run_elapsed_time)
 
-        collated_results = self._collate_results(config, run_elapsed_time)
-        collated_results_path = self._multirun_dir / _COLLATED_RESULTS_FILENAME
+        self._save_to_disk(run)
+        if "dynamodb" in config:
+            self._write_to_dynamodb(config.dynamodb.region, config.dynamodb.table, run)
+        else:
+            logger.info("DynamoDB config not provided: skipping write to table...")
 
-        logger.info("Saving collated results to: %s", collated_results_path)
-        with open(collated_results_path, "w") as f:
-            json.dump(collated_results, f, ensure_ascii=False, indent=4)
-        logger.info("Collated results saved successfully")
+    def _build_run(self, config: DictConfig, run_elapsed_time: float) -> Run:
+        all_job_results = []
+        for entry in self._multirun_path.glob(f"**/{JOB_RESULTS_FILENAME}"):
+            if entry.is_file():
+                all_job_results.append(json.loads(entry.read_text()))
 
-    def _collate_results(
-        self, config: DictConfig, run_elapsed_time: float
-    ) -> CollatedResults:
-        collated_results = []
-        for file in self._multirun_dir.glob("*/**/result*.json"):
-            collated_results.append(json.loads(file.read_text()))
-
-        logger.info("Collated %i result files", len(collated_results))
+        logger.info("Collected %i job results", len(all_job_results))
         return {
-            "metadata": {
-                "python_version": sys.version,
-                "pytorch_version": torch.__version__,
-                "hydra_version": config.hydra.runtime.version,
-                "ec2_metadata": get_ec2_metadata(),
-                "run_elapsed_time_s": run_elapsed_time,
-                "number_of_jobs": len(collated_results),
+            "run_id": str(uuid.uuid4()),
+            "timestamp_utc": datetime.now(timezone.utc).timestamp(),
+            "scenario": config.hydra.job.name,
+            "versions": {
+                "python": sys.version,
+                "pytorch": torch.__version__,
+                "hydra": config.hydra.runtime.version,
+                "s3torchconnector": s3torchconnector.__version__,
             },
-            "results": collated_results,
+            "ec2_metadata": _get_ec2_metadata(),
+            "run_elapsed_time_s": run_elapsed_time,
+            "number_of_jobs": len(all_job_results),
+            "all_job_results": all_job_results,
         }
 
+    def _save_to_disk(self, run: Run) -> None:
+        run_filepath = self._multirun_path / RUN_FILENAME
 
-@lru_cache
-def get_ec2_metadata() -> Union[EC2Metadata, None]:
-    """Get some EC2 metadata by running the `/opt/aws/bin/ec2-metadata` command.
+        logger.info("Saving run to: %s", run_filepath)
+        with open(run_filepath, "w") as f:
+            json.dump(run, f, ensure_ascii=False, indent=2)
+        logger.info("Run saved successfully")
 
-    The command's output is a single string of text, in a JSON-like format (_but not quite JSON_): hence, its content
-    is parsed using regex.
+    @staticmethod
+    def _write_to_dynamodb(region: str, table_name: str, run: Run) -> None:
+        dynamodb = boto3.resource("dynamodb", region_name=region)
+        table = dynamodb.Table(table_name)
 
-    The function's call is cached, so we don't execute the command multiple times per runs.
+        # `parse_float=Decimal` is required for DynamoDB (the latter does not work with floats), so we perform that
+        # (strange) conversion through dumping then loading again the :class:`Run` object.
+        run_json = json.loads(json.dumps(run), parse_float=Decimal)
+
+        try:
+            logger.info("Putting item into table: %s", table_name)
+            table.put_item(Item=run_json)
+            logger.info("Put item into table successfully")
+        except ClientError:
+            logger.error("Couldn't put item into table %s", table, exc_info=True)
+
+
+def _get_ec2_metadata() -> Union[EC2Metadata, None]:
+    """Get some EC2 metadata.
+
+    See also https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instancedata-inside-access.
     """
-    result = subprocess.run(
-        "/opt/aws/bin/ec2-metadata", capture_output=True, text=True, timeout=5
+    token = requests.put(
+        URL_IMDS_TOKEN,
+        headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+        timeout=5.0,
     )
-    if result.returncode == 0:
-        metadata = result.stdout
-        instance_type = re.search("instance-type: (.*)", metadata).group(1)
-        placement = re.search("placement: (.*)", metadata).group(1)
-        if instance_type and placement:
-            return {"instance_type": instance_type, "placement": placement}
-    return None
+    if token.status_code != 200:
+        logger.warning("Failed to get EC2 metadata (acquiring token): %s", token)
+        return None
+
+    document = requests.get(
+        URL_IMDS_DOCUMENT, headers={"X-aws-ec2-metadata-token": token.text}, timeout=5.0
+    )
+    if document.status_code != 200:
+        logger.warning("Failed to get EC2 metadata (fetching document): %s", document)
+        return None
+
+    payload = document.json()
+    return {
+        "architecture": payload["architecture"],
+        "image_id": payload["imageId"],
+        "instance_type": payload["instanceType"],
+        "region": payload["region"],
+    }

--- a/s3torchbenchmarking/src/s3torchbenchmarking/lightning_checkpointing/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/lightning_checkpointing/benchmark.py
@@ -13,15 +13,17 @@ from omegaconf import DictConfig
 from torch.utils.data import DataLoader
 from torchdata.datapipes.iter import IterableWrapper  # type: ignore
 
-from s3torchconnector.lightning import S3LightningCheckpoint
-from .checkpoint_profiler import CheckpointProfiler
-from ..benchmark_utils import (
+from s3torchbenchmarking.benchmark_utils import (
     ResourceMonitor,
     build_checkpoint_uri,
     build_random_suffix,
 )
-from ..job_results import save_job_results
-from ..models import get_benchmark_model, LightningAdapter
+from s3torchbenchmarking.job_results import save_job_results
+from s3torchbenchmarking.lightning_checkpointing.checkpoint_profiler import (
+    CheckpointProfiler,
+)
+from s3torchbenchmarking.models import get_benchmark_model, LightningAdapter
+from s3torchconnector.lightning import S3LightningCheckpoint
 
 logger = logging.getLogger(__name__)
 
@@ -70,3 +72,7 @@ def run_benchmark(config: DictConfig):
     }
 
     save_job_results(config, benchmark_model, metrics)
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -64,8 +64,6 @@ class BenchmarkModel:
         return (param_size + buffer_size) / 1024**2
 
 
-# NOTE: keys below are later used to construct a filename, so make sure they do not contain characters that will not
-# play well with filesystems (e.g., '/').
 _MODELS = {
     # ~350 MB model
     "vit-base": BenchmarkModel(

--- a/s3torchbenchmarking/utils/collect_and_write_to_dynamodb.py
+++ b/s3torchbenchmarking/utils/collect_and_write_to_dynamodb.py
@@ -1,0 +1,68 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+"""Collect and write collated results to DynamoDB table.
+
+This script collects all "collated_results.json" files in a given directory, and write them (in batch) to the specified
+DynamoDB table.
+
+Requires AWS credentials to be correctly set beforehand (env var).
+"""
+
+import argparse
+import json
+import logging
+from decimal import Decimal
+from pathlib import Path
+from typing import List, Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+_RUN_FILENAME = "run.json"
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def collect_collated_results(results_dir: str) -> List[Any]:
+    all_job_results = []
+    for entry in Path(results_dir).glob(f"**/{_RUN_FILENAME}"):
+        if entry.is_file():
+            with open(entry, "r") as f:
+                all_job_results.append(json.load(f, parse_float=Decimal))
+
+    logger.info("Collected %i job results", len(all_job_results))
+    return all_job_results
+
+
+def write_collated_results_to_dynamodb(
+    collated_results: List[Any], region: str, table: str
+) -> None:
+    dynamodb = boto3.resource("dynamodb", region_name=region)
+
+    try:
+        with dynamodb.Table(table).batch_writer() as writer:
+            for collated_result in collated_results:
+                writer.put_item(Item=collated_result)
+    except ClientError:
+        logger.error("Couldn't load data into table %s", table, exc_info=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect and write collated results to DynamoDB table"
+    )
+    parser.add_argument(
+        "collated_results_dir", help="directory where the collated results are"
+    )
+    parser.add_argument("region", help="region where the DynamoDB table is")
+    parser.add_argument("table", help="DynamoDB table name")
+    args = parser.parse_args()
+
+    collated_results = collect_collated_results(args.collated_results_dir)
+    write_collated_results_to_dynamodb(collated_results, args.region, args.table)
+
+
+if __name__ == "__main__":
+    main()

--- a/s3torchbenchmarking/utils/prepare_ec2_instance.sh
+++ b/s3torchbenchmarking/utils/prepare_ec2_instance.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Script to prepare an EC2 instance for PyTorch benchmarks.
+
+set -euo pipefail
+
+# Sanity check
+sudo yum -y upgrade # OR, `sudo apt -y upgrade`
+
+# Activate the default PyTorch env
+#
+# This command only works on specific AMI (DL-AMI): make sure to check the compatibility between the latter and the EC2
+# instance type currently in use (if incompatible, the command will either fail or generate a warning).
+source activate pytorch
+
+# Install Rust (https://www.rust-lang.org/learn/get-started)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+. "$HOME/.cargo/env"
+
+# Addresses error "RuntimeError: operator torchvision::nms does not exist" while trying the run the benchmarks
+conda install -y pytorch torchvision torchaudio pytorch-cuda=12.4 -c pytorch -c nvidia
+
+# Addresses error "TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'" while
+# trying to install s3torchbenchmarking
+pip install "setuptools<71"
+
+# Required to build s3torchconnectorclient (see its README)
+sudo yum -y install cmake3 clang
+
+pip install 's3torchconnector[lightning,dcp]'
+cd s3torchbenchmarking && pip install -e .

--- a/s3torchbenchmarking/utils/prepare_nvme.sh
+++ b/s3torchbenchmarking/utils/prepare_nvme.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 #
-# Mount an NVMe drive (by default, at `./nvme/`) where this script is run.
+# Mount an NVMe drive (by default, at `./nvme/`) relative to where this script is run. If a drive is already mounted at
+# the specified location, clear its content.
 
-nvme_dir=${1:-"./nvme/"}
+nvme_dir=${1:-"./nvme/"} # default value
 
-sudo umount "$nvme_dir"
-sudo rm -rf "$nvme_dir"
-sudo mkfs -t xfs -f /dev/nvme1n1
-sudo mkdir "$nvme_dir"
-sudo mount /dev/nvme1n1 "$nvme_dir"
-sudo chmod 777 "$nvme_dir"
+if ! mountpoint -q "$nvme_dir"; then
+  rm -rf "$nvme_dir"
+  sudo mkfs -t xfs /dev/nvme1n1
+  mkdir -p "$nvme_dir"
+  sudo mount /dev/nvme1n1 "$nvme_dir"
+  sudo chmod 777 "$nvme_dir"
+else
+  rm -rf "${nvme_dir:?}"/* # https://www.shellcheck.net/wiki/SC2115
+fi

--- a/s3torchbenchmarking/utils/run_benchmarks.sh
+++ b/s3torchbenchmarking/utils/run_benchmarks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Template script to run other benchmarks (not to be used directly).
+
+set -euo pipefail
+
+scenario=$1        # name of the scenario
+region=${2:-}      # DynamoDB region (for writing results)
+table=${3:-}       # DynamoDB table name (for writing results)
+nvme_dir="./nvme/" # local path for saving checkpoints
+
+# Prepare NVMe drive mount
+./utils/prepare_nvme.sh "$nvme_dir"
+
+# Run benchmarks; will write to DynamoDB table, if provided
+dynamodb_args=()
+if [ -n "$region" ] && [ -n "$table" ]; then
+  dynamodb_args+=(+dynamodb.region="$region" +dynamodb.table="$table")
+fi
+
+python ./src/s3torchbenchmarking/"$scenario"/benchmark.py -cd conf -cn "$scenario" path="$nvme_dir" "${dynamodb_args[@]}"

--- a/s3torchbenchmarking/utils/run_dcp_benchmarks.sh
+++ b/s3torchbenchmarking/utils/run_dcp_benchmarks.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
+#
+# Run PyTorch’s Distributed Checkpointing (DCP) benchmarks.
 
-nvme_dir="./nvme/"
-nvme_suffix="dcp/"
-
-# Prepare NVMe drive mount
-./utils/prepare_nvme.sh $nvme_dir
-
-# Run benchmarks
-s3torch-benchmark-dcp -cd conf -cn dcp path="$nvme_dir/$nvme_suffix"
+./utils/run_benchmarks.sh dcp "$@"

--- a/s3torchbenchmarking/utils/run_lightning_benchmarks.sh
+++ b/s3torchbenchmarking/utils/run_lightning_benchmarks.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
+#
+# Run PyTorch Lightning Checkpointing benchmarks.
 
-RESULTS_BUCKET_NAME=$1
-RESULTS_PREFIX=$2
-
-nvme_dir="./nvme/lightning/"
-
-# Prepare NVMe drive mount
-./utils/prepare_nvme.sh $nvme_dir
-
-# Run benchmarks
-s3torch-benchmark-lightning -cd conf -cn lightning_checkpointing path=$nvme_dir
-
-# Upload results to an S3 bucket
-python ./utils/upload_colated_results_to_s3.py "./multirun" "${RESULTS_BUCKET_NAME}" "${RESULTS_PREFIX}" "checkpoint"
+./utils/run_benchmarks.sh lightning_checkpointing "$@"


### PR DESCRIPTION
Create a "constants.py" file. Improve Hydra's callback behaviour and
save run results to DynamoDB (optionally). Improve shell scripts used to
run the benchmarks. Add a script to prepare an EC2 instance for
benchmarking.

--------

By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
