### PR TITLE
Update torch version and bind torchdata to last version with DataPipes

### DIFF
--- a/s3torchbenchmarking/pyproject.toml
+++ b/s3torchbenchmarking/pyproject.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 dependencies = [
     # TODO: remove "!= 2.3.0" restriction once https://github.com/pytorch/data/issues/1244 is fixed
     # TODO: remove "< 2.5" restriction once https://github.com/pytorch/pytorch/issues/138333 is fixed
-    "torch >= 2.0.1, != 2.3.0, < 2.5",
+    "torch >= 2.0.1, != 2.3.0, != 2.5.0",
     "lightning >= 2.0",
     "s3torchconnector",
     "hydra-core",
-    "torchdata>=0.6.1",
+    "torchdata>=0.6.1, <=0.9.0", # we have dependency on deprecated DataPipes, which were removed in 0.10.0
     "torchvision",
     "s3fs>=2024.6.1",
     "transformers",

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "torch >= 2.0.1, < 2.5", # TODO: remove "< 2.5" restriction once https://github.com/pytorch/pytorch/issues/138333 is fixed
+    "torch >= 2.0.1, != 2.5.0",
     "s3torchconnectorclient >= 1.3.0",
 ]
 
@@ -37,7 +37,7 @@ test = [
 ]
 
 e2e = [
-    "torchdata",
+    "torchdata<=0.9.0", # we have dependency on deprecated DataPipes, which were removed in 0.10.0
     "torchvision",
     "Pillow>=10.3.0",
     "boto3",
@@ -56,7 +56,7 @@ lightning-tests = [
 
 dcp = [
     "tenacity",
-    "torch >= 2.3, < 2.5", # TODO: remove "< 2.5" restriction once https://github.com/pytorch/pytorch/issues/138333 is fixed
+    "torch >= 2.3, != 2.5.0",
 ]
 
 dcp-test = [


### PR DESCRIPTION
## Description
Update dependency on torch to exclude 2.5.0 version that contains issue https://github.com/pytorch/pytorch/issues/138333
Limit torchdata version by 0.9.0 until we remove dependency on deprecated DataPipes, that were removed from 0.10.0

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
