### PR TITLE
feat(benchmarks): add Jupyter Notebook for results exploitation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ multirun/
 # Unit test / coverage reports
 .hypothesis/
 
+# Jupyter Notebook
+.ipynb_checkpoints
+
 # Prevent publishing file with third party licenses
 THIRD-PARTY-LICENSES

--- a/s3torchbenchmarking/benchmark_results_aggregator.ipynb
+++ b/s3torchbenchmarking/benchmark_results_aggregator.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "36f63340-79b9-4f61-a6a3-c4883071c0b3",
+   "metadata": {},
+   "source": [
+    "# Benchmark results aggregator\n",
+    "\n",
+    "This notebook helps to aggregate the benchmark results collected from a DynamoDB table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6522fc8a931ffbc3",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T16:15:52.368674Z",
+     "start_time": "2024-12-17T16:15:51.425605Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%capture --no-display\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "%pip install -q boto3 numpy pandas python-dotenv openpyxl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4a896ce-8398-4d20-8270-7f5b77206d2b",
+   "metadata": {},
+   "source": [
+    "### Initialization (imports and constants)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a371fc9062af6126",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T16:15:52.388081Z",
+     "start_time": "2024-12-17T16:15:52.375379Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Define the environment variables below in a \".env\" file: `load_dotenv()`\n",
+    "# will source them automatically.\n",
+    "load_dotenv()\n",
+    "\n",
+    "# AWS region and table name for where the benchmark results are stored.\n",
+    "REGION = os.environ.get(\"DYNAMODB_REGION\")\n",
+    "TABLE = os.environ.get(\"DYNAMODB_TABLE\")\n",
+    "\n",
+    "# S3 Connector for PyTorch versions to query, to compare benchmark results.\n",
+    "PREVIOUS_VERSION = \"1.2.7\"\n",
+    "NEXT_VERSION = \"1.3.0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b06aa712-e2c1-48ea-8cc1-a8cd14701cf9",
+   "metadata": {},
+   "source": [
+    "### Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e14b9efad6ae3ad6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T16:16:16.363274Z",
+     "start_time": "2024-12-17T16:16:16.348512Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from typing import List\n",
+    "\n",
+    "import numpy as np\n",
+    "import boto3\n",
+    "\n",
+    "\n",
+    "def query_dynamodb(\n",
+    "    region: str, table_name: str, old_version: str, new_version: str\n",
+    ") -> List[dict]:\n",
+    "    \"\"\"Query DynamoDB for the latest run results.\"\"\"\n",
+    "    dynamodb = boto3.resource(\"dynamodb\", region_name=region)\n",
+    "\n",
+    "    statement = f'SELECT * FROM \"{table_name}\" WHERE s3torchconnector_version IN [?, ?]'\n",
+    "    params = [old_version, new_version]\n",
+    "    response = dynamodb.meta.client.execute_statement(\n",
+    "        Statement=statement, Parameters=params\n",
+    "    )\n",
+    "\n",
+    "    return response[\"Items\"]\n",
+    "\n",
+    "\n",
+    "def transform(run_results: List[dict]) -> List[dict]:\n",
+    "    \"\"\"Build a list of row to be later concatenated in a :class:`pd.DataFrame`.\"\"\"\n",
+    "    rows = []\n",
+    "    for run_result in run_results:\n",
+    "        for job_result in run_result[\"job_results\"]:\n",
+    "            metrics_averaged = {\n",
+    "                k: float(np.mean(v))  # `float()` to cast away the `Decimal` part\n",
+    "                for k, v in job_result[\"metrics\"].items()\n",
+    "                if k != \"utilization\"\n",
+    "            }\n",
+    "            row = {\n",
+    "                \"version\": run_result[\"s3torchconnector_version\"],\n",
+    "                \"scenario\": run_result[\"scenario\"],\n",
+    "                \"disambiguator\": run_result.get(\"disambiguator\"),\n",
+    "                \"timestamp_utc\": datetime.fromtimestamp(\n",
+    "                    float(run_result[\"timestamp_utc\"])\n",
+    "                ),\n",
+    "                **metrics_averaged,\n",
+    "                \"config\": job_result[\"config\"],\n",
+    "            }\n",
+    "            rows.append(row)\n",
+    "\n",
+    "    return rows"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94f68eef52fb0b5c",
+   "metadata": {},
+   "source": [
+    "### Exploit data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "be008fb6acf09055",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T16:16:18.143297Z",
+     "start_time": "2024-12-17T16:16:18.040538Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "_run_results = query_dynamodb(REGION, TABLE, PREVIOUS_VERSION, NEXT_VERSION)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac3597a1",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T16:16:18.808673Z",
+     "start_time": "2024-12-17T16:16:18.782056Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "_data = transform(_run_results)\n",
+    "_table = pd.json_normalize(_data).set_index(\"version\")\n",
+    "_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b4eed2752e6add17",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-17T16:16:56.380528Z",
+     "start_time": "2024-12-17T16:16:56.365683Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import string\n",
+    "import random\n",
+    "\n",
+    "_suffix = \"\".join(random.choices(string.ascii_letters, k=5))\n",
+    "_table.to_csv(f\"benchmark_results_{_suffix}.csv\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a Jupyter Notebook to fetch and transform benchmark results into Pandas `DataFrame` and CSV file.

--------

By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
