### PR TITLE
Ensure path exists, before writing dataset config file

### DIFF
--- a/s3torchbenchmarking/src/s3torchbenchmarking/datagen.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/datagen.py
@@ -132,6 +132,7 @@ class Utils:
     def write_dataset_config(disambiguator: str, dataset_cfg: Dict[str, Any]):
         current_dir = os.getcwd()
         cfg_path = Path(current_dir) / "conf" / "dataset" / f"{disambiguator}.yaml"
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
         with open(cfg_path, "w") as outfile:
             yaml.dump(dataset_cfg, outfile, default_flow_style=False)
             click.echo(f"Dataset Configuration created at: {cfg_path}")


### PR DESCRIPTION
## Description
We have deleted `dataset` folder from `s3torchbenchmarking/conf/`. That caused `datagen` to fail create dataset config file in non existed folder. Added line to create all missing directories in path for dataset config.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
