### PR TITLE
Escape special characters in path name for COPY request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## TBD
+
+### New features
+* Escape special characters in rename operation (#297)
+
+### Breaking changes
+* No breaking changes.
+
 ## v1.3.1 (January 10, 2025)
 
 ### New features

--- a/s3torchconnector/src/s3torchconnector/dcp/s3_file_system.py
+++ b/s3torchconnector/src/s3torchconnector/dcp/s3_file_system.py
@@ -127,7 +127,7 @@ class S3FileSystem(FileSystemBase):
         new_path_str = _path_or_str_to_str(new_path)
 
         old_bucket, old_key = parse_s3_uri(old_path_str)
-        escaped_old_key = self._uri_escape_path(old_key)
+        escaped_old_key = self._escape_path(old_key)
         logger.debug("rename: escaped version of the source key: %s", escaped_old_key)
         new_bucket, new_key = parse_s3_uri(new_path_str)
 
@@ -202,14 +202,14 @@ class S3FileSystem(FileSystemBase):
         self._client.delete_object(bucket_name, old_key)
 
     @staticmethod
-    def _uri_escape_path(string):
-        """Return a version of the string with special characters escaped.
+    def _escape_path(string):
+        """URL-encodes path segments while preserving '/' separators using urllib.parse.quote().
 
         Args:
-            string (str): The string to escape.
+            string (str): URL path string to escape
 
         Returns:
-            str: The escaped string.
+            str: Path string with each segment percent-encoded, separators preserved
         """
         if not string:
             return string

--- a/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
+++ b/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
@@ -207,7 +207,7 @@ def test_dcp_load_non_existing_s3_uri(checkpoint_directory):
     print("Test passed: Raised CheckpointException.")
 
 
-@pytest.mark.parametrize("path", ["test_rename_src", "test_[+rename]!@£$%^&*_(src)"])
+@pytest.mark.parametrize("path", ["test_rename_src", "test_[+re.name]!@£$%^&*_(src)"])
 def test_successful_rename(checkpoint_directory, path):
     src_path = f"{checkpoint_directory.s3_uri}{path}"
     test_data = {

--- a/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
+++ b/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
@@ -207,8 +207,9 @@ def test_dcp_load_non_existing_s3_uri(checkpoint_directory):
     print("Test passed: Raised CheckpointException.")
 
 
-def test_successful_rename(checkpoint_directory):
-    src_path = f"{checkpoint_directory.s3_uri}test_rename_src"
+@pytest.mark.parametrize("path", ["test_rename_src", "test_[+rename]!@£$%^&*_(src)"])
+def test_successful_rename(checkpoint_directory, path):
+    src_path = f"{checkpoint_directory.s3_uri}{path}"
     test_data = {
         "tensor1": torch.randn(10, 10),
         "tensor2": torch.randn(5, 5),

--- a/s3torchconnector/tst/unit/dcp/test_s3_file_system.py
+++ b/s3torchconnector/tst/unit/dcp/test_s3_file_system.py
@@ -124,6 +124,34 @@ def test_rename_raises_when_retries_fail(caplog):
     assert "this was the 3rd time calling it" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "source_path,expected_path",
+    [
+        # Basic cases
+        ("simple/path", "simple/path"),
+        ("", ""),
+        (None, None),
+        # Special characters
+        ("path with spaces/file.txt", "path%20with%20spaces/file.txt"),
+        ("special&?=chars", "special%26%3F%3Dchars"),
+        # Unicode characters
+        ("path/測試/файл", "path/%E6%B8%AC%E8%A9%A6/%D1%84%D0%B0%D0%B9%D0%BB"),
+        # Multiple segments with special chars
+        (
+            "path with spaces/file name?/special&.txt",
+            "path%20with%20spaces/file%20name%3F/special%26.txt",
+        ),
+        # Reserved characters
+        ("path+plus/hash#tag", "path%2Bplus/hash%23tag"),
+        ("path@email/dollar$", "path%40email/dollar%24"),
+        # Multiple consecutive slashes (if handled)
+        ("path//double/slash", "path//double/slash"),
+    ],
+)
+def test_escape_path(source_path, expected_path):
+    assert S3FileSystem._escape_path(source_path) == expected_path
+
+
 @pytest.mark.skip(reason="method not implemented (no-op)")
 def test_mkdir():
     pass


### PR DESCRIPTION
## Description
If path contains special characters COPY request will fail. We need to escape special characters for COPY request.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
https://github.com/awslabs/s3-connector-for-pytorch/issues/295

## Testing
Update integration tests

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
