### PR TITLE
Feature/support dots in bucket name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## TBD
 
 ### New features
+* Consume mountpoint-s3-client changes with support for dots in bucket name for COPY operation introduced in CRT (#300)
 * Escape special characters in rename operation (#297)
 
 ### Breaking changes
-* No breaking changes.
+* Internal S3Client now returns `HeadObjectResult` instead of `ObjectInfo`. The only difference is that `HeadObjectResult` doesn't have `key` field. 
 
 ## v1.3.1 (January 10, 2025)
 

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "s3torchconnector"
-version = "1.3.1"
+version = "1.3.2"
 description = "S3 connector integration for PyTorch"
 requires-python = ">=3.8,<3.13"
 readme = "README.md"
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "torch >= 2.0.1, != 2.5.0",
-    "s3torchconnectorclient == 1.3.1",
+    "s3torchconnectorclient == 1.3.2",
 ]
 
 [project.optional-dependencies]

--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -13,6 +13,7 @@ from .s3client_config import S3ClientConfig
 from s3torchconnectorclient._mountpoint_s3_client import (
     MountpointS3Client,
     ObjectInfo,
+    HeadObjectResult,
     ListObjectStream,
     GetObjectStream,
 )
@@ -123,7 +124,7 @@ class S3Client:
         return self._client.list_objects(bucket, prefix, delimiter, max_keys)
 
     # TODO: We need ObjectInfo on dataset side
-    def head_object(self, bucket: str, key: str) -> ObjectInfo:
+    def head_object(self, bucket: str, key: str) -> HeadObjectResult:
         log.debug(f"HeadObject s3://{bucket}/{key}")
         return self._client.head_object(bucket, key)
 

--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -24,18 +24,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,7 +39,7 @@ dependencies = [
  "rustix",
  "slab",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -101,16 +89,14 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -286,13 +272,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -489,15 +481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,12 +654,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -763,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.22.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -779,9 +765,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2469bf1d23727d14e3d94f6c4b854aa45840d9a768cb74598b7b26773229a97d"
+checksum = "8676f5a43b1f347642d6f96bdb44172173ec9bb652b61fc9ff88da35ce11fb97"
 dependencies = [
  "async-io",
  "async-lock",
@@ -791,13 +777,10 @@ dependencies = [
  "built",
  "const_format",
  "futures",
- "lazy_static",
- "libc",
  "md-5",
  "metrics",
  "mountpoint-s3-crt",
  "mountpoint-s3-crt-sys",
- "once_cell",
  "percent-encoding",
  "pin-project",
  "platform-info",
@@ -806,7 +789,7 @@ dependencies = [
  "regex",
  "serde_json",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.11",
  "time",
  "tracing",
  "xmltree",
@@ -814,33 +797,30 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b86188158f1d2d0582683789c0ecd1edd45581f84bc665e4c4edeb60984954e"
+checksum = "8468ebaaf2144abb5127ca6a3725cfc0227ef4687b464df7759ddad2aa722b0f"
 dependencies = [
- "async-channel",
  "futures",
  "libc",
  "log",
  "mountpoint-s3-crt-sys",
  "smallstr",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e802f03ec1096a166dce1a61e686a115f01c568ad87346a2094fb2ed07141c"
+checksum = "743fc5652ecaa894bf3ed5e59d2404a2f1e5fc2274f148e31b90f2476a629a92"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "libc",
- "log",
  "rustflags",
- "smallstr",
  "which",
 ]
 
@@ -898,12 +878,6 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -971,7 +945,7 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1158,9 +1132,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustflags"
@@ -1178,7 +1152,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1201,7 +1175,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "s3torchconnectorclient"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "built",
  "futures",
@@ -1337,7 +1311,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1346,7 +1320,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1354,6 +1337,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1429,7 +1423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
@@ -1555,12 +1549,12 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
-version = "6.0.3"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
 dependencies = [
  "either",
- "home",
+ "env_home",
  "rustix",
  "winsafe",
 ]
@@ -1586,15 +1580,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1695,9 +1680,9 @@ checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
 
 [[package]]
 name = "xmltree"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+checksum = "b619f8c85654798007fb10afa5125590b43b088c225a25fc2fec100a9fad0fc6"
 dependencies = [
  "xml-rs",
 ]

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -18,8 +18,8 @@ built = "0.7"
 [dependencies]
 pyo3 = "0.22.4"
 futures = "0.3.28"
-mountpoint-s3-client = { version = "0.11.0", features = ["mock"] }
-mountpoint-s3-crt = "0.10.0"
+mountpoint-s3-client = { version = "0.12.0", features = ["mock"] }
+mountpoint-s3-crt = "0.11.0"
 log = "0.4.20"
 tracing = { version = "0.1.40", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"]}

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3torchconnectorclient"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 publish = false
 license = "BSD-3-Clause"

--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "s3torchconnectorclient"
-version = "1.3.1"
+version = "1.3.2"
 description = "Internal S3 client implementation for s3torchconnector"
 requires-python = ">=3.8,<3.13"
 readme = "README.md"

--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/_mountpoint_s3_client.pyi
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/_mountpoint_s3_client.pyi
@@ -33,7 +33,7 @@ class MountpointS3Client:
     def list_objects(
         self, bucket: str, prefix: str = "", delimiter: str = "", max_keys: int = 1000
     ) -> ListObjectStream: ...
-    def head_object(self, bucket: str, key: str) -> ObjectInfo: ...
+    def head_object(self, bucket: str, key: str) -> HeadObjectResult: ...
     def delete_object(self, bucket: str, key: str) -> None: ...
     def copy_object(
         self, src_bucket: str, src_key: str, dst_bucket: str, dst_key: str
@@ -93,6 +93,22 @@ class ObjectInfo:
     def __init__(
         self,
         key: str,
+        etag: str,
+        size: int,
+        last_modified: int,
+        storage_class: Optional[str],
+        restore_status: Optional[RestoreStatus],
+    ): ...
+
+class HeadObjectResult:
+    etag: str
+    size: int
+    last_modified: int
+    storage_class: Optional[str]
+    restore_status: Optional[RestoreStatus]
+
+    def __init__(
+        self,
         etag: str,
         size: int,
         last_modified: int,

--- a/s3torchconnectorclient/rust/src/lib.rs
+++ b/s3torchconnectorclient/rust/src/lib.rs
@@ -11,6 +11,7 @@ use crate::mountpoint_s3_client::MountpointS3Client;
 use crate::put_object_stream::PutObjectStream;
 use crate::python_structs::py_list_object_result::PyListObjectResult;
 use crate::python_structs::py_object_info::PyObjectInfo;
+use crate::python_structs::py_head_object_result::PyHeadObjectResult;
 use crate::python_structs::py_restore_status::PyRestoreStatus;
 use pyo3::prelude::*;
 
@@ -36,6 +37,7 @@ fn make_lib(py: Python, mountpoint_s3_client: &Bound<'_, PyModule>) -> PyResult<
     mountpoint_s3_client.add_class::<PutObjectStream>()?;
     mountpoint_s3_client.add_class::<PyListObjectResult>()?;
     mountpoint_s3_client.add_class::<PyObjectInfo>()?;
+    mountpoint_s3_client.add_class::<PyHeadObjectResult>()?;
     mountpoint_s3_client.add_class::<PyRestoreStatus>()?;
     mountpoint_s3_client.add("S3Exception", py.get_type_bound::<S3Exception>())?;
     mountpoint_s3_client.add("__version__", build_info::FULL_VERSION)?;

--- a/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
+++ b/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
@@ -21,9 +21,9 @@ use crate::get_object_stream::GetObjectStream;
 use crate::list_object_stream::ListObjectStream;
 use crate::mountpoint_s3_client_inner::{MountpointS3ClientInner, MountpointS3ClientInnerImpl};
 use crate::put_object_stream::PutObjectStream;
-use crate::python_structs::py_object_info::PyObjectInfo;
 
 use crate::build_info;
+use crate::python_structs::py_head_object_result::PyHeadObjectResult;
 
 #[pyclass(
     name = "MountpointS3Client",
@@ -149,7 +149,7 @@ impl MountpointS3Client {
         slf: PyRef<'_, Self>,
         bucket: String,
         key: String
-    ) -> PyResult<PyObjectInfo> {
+    ) -> PyResult<PyHeadObjectResult> {
         let params = HeadObjectParams::default();
         slf.client.head_object(slf.py(), bucket, key, params)
     }

--- a/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
+++ b/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
@@ -6,7 +6,7 @@
 use mountpoint_s3_client::config::{
     AddressingStyle, EndpointConfig, S3ClientAuthConfig, S3ClientConfig,
 };
-use mountpoint_s3_client::types::PutObjectParams;
+use mountpoint_s3_client::types::{GetObjectParams, HeadObjectParams, PutObjectParams};
 use mountpoint_s3_client::user_agent::UserAgent;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::common::allocator::Allocator;
@@ -117,7 +117,8 @@ impl MountpointS3Client {
         bucket: String,
         key: String,
     ) -> PyResult<GetObjectStream> {
-        slf.client.get_object(slf.py(), bucket, key)
+        let params = GetObjectParams::default();
+        slf.client.get_object(slf.py(), bucket, key, params)
     }
 
     #[pyo3(signature = (bucket, prefix=String::from(""), delimiter=String::from(""), max_keys=1000))]
@@ -147,9 +148,10 @@ impl MountpointS3Client {
     pub fn head_object(
         slf: PyRef<'_, Self>,
         bucket: String,
-        key: String,
+        key: String
     ) -> PyResult<PyObjectInfo> {
-        slf.client.head_object(slf.py(), bucket, key)
+        let params = HeadObjectParams::default();
+        slf.client.head_object(slf.py(), bucket, key, params)
     }
 
     pub fn delete_object(slf: PyRef<'_, Self>, bucket: String, key: String) -> PyResult<()> {
@@ -199,7 +201,7 @@ impl MountpointS3Client {
     ) -> Self
     where
         Client: ObjectClient + Sync + Send + 'static,
-        <Client as ObjectClient>::GetObjectRequest: Unpin + Sync,
+        <Client as ObjectClient>::GetObjectResponse: Unpin + Sync,
         <Client as ObjectClient>::PutObjectRequest: Sync,
     {
         Self {

--- a/s3torchconnectorclient/rust/src/mountpoint_s3_client_inner.rs
+++ b/s3torchconnectorclient/rust/src/mountpoint_s3_client_inner.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use futures::executor::block_on;
 use futures::TryStreamExt;
-use mountpoint_s3_client::types::{CopyObjectParams, ListObjectsResult, PutObjectParams};
+use mountpoint_s3_client::types::{CopyObjectParams, GetObjectParams, HeadObjectParams, ListObjectsResult, PutObjectParams};
 use mountpoint_s3_client::ObjectClient;
 use pyo3::{PyResult, Python};
 
@@ -24,7 +24,7 @@ pub type MPGetObjectClosure =
 /// us to specify the additional types (GetObjectResult, PutObjectResult, ClientError), which
 /// we don't want to do.
 pub(crate) trait MountpointS3ClientInner {
-    fn get_object(&self, py: Python, bucket: String, key: String) -> PyResult<GetObjectStream>;
+    fn get_object(&self, py: Python, bucket: String, key: String, params: GetObjectParams) -> PyResult<GetObjectStream>;
     fn list_objects(
         &self,
         bucket: &str,
@@ -40,7 +40,7 @@ pub(crate) trait MountpointS3ClientInner {
         key: String,
         params: PutObjectParams,
     ) -> PyResult<PutObjectStream>;
-    fn head_object(&self, py: Python, bucket: String, key: String) -> PyResult<PyObjectInfo>;
+    fn head_object(&self, py: Python, bucket: String, key: String, params: HeadObjectParams) -> PyResult<PyObjectInfo>;
     fn delete_object(&self, py: Python, bucket: String, key: String) -> PyResult<()>;
     fn copy_object(
         &self,
@@ -65,11 +65,11 @@ impl<T: ObjectClient> MountpointS3ClientInnerImpl<T> {
 impl<Client> MountpointS3ClientInner for MountpointS3ClientInnerImpl<Client>
 where
     Client: ObjectClient,
-    <Client as ObjectClient>::GetObjectRequest: Sync + Unpin + 'static,
+    <Client as ObjectClient>::GetObjectResponse: Sync + Unpin + 'static,
     <Client as ObjectClient>::PutObjectRequest: Sync + 'static,
 {
-    fn get_object(&self, py: Python, bucket: String, key: String) -> PyResult<GetObjectStream> {
-        let request = self.client.get_object(&bucket, &key, None, None);
+    fn get_object(&self, py: Python, bucket: String, key: String, params: GetObjectParams) -> PyResult<GetObjectStream> {
+        let request = self.client.get_object(&bucket, &key, &params);
 
         // TODO - Look at use of `block_on` and see if we can future this.
         let mut request = py.allow_threads(|| block_on(request).map_err(python_exception))?;
@@ -110,8 +110,8 @@ where
         Ok(PutObjectStream::new(request, bucket, key))
     }
 
-    fn head_object(&self, py: Python, bucket: String, key: String) -> PyResult<PyObjectInfo> {
-        let request = self.client.head_object(&bucket, &key);
+    fn head_object(&self, py: Python, bucket: String, key: String, params: HeadObjectParams) -> PyResult<PyObjectInfo> {
+        let request = self.client.head_object(&bucket, &key, &params);
 
         // TODO - Look at use of `block_on` and see if we can future this.
         let request = py.allow_threads(|| block_on(request).map_err(python_exception))?;

--- a/s3torchconnectorclient/rust/src/python_structs.rs
+++ b/s3torchconnectorclient/rust/src/python_structs.rs
@@ -6,3 +6,4 @@
 pub(crate) mod py_list_object_result;
 pub(crate) mod py_object_info;
 pub(crate) mod py_restore_status;
+pub(crate) mod py_head_object_result;

--- a/s3torchconnectorclient/rust/src/python_structs/py_head_object_result.rs
+++ b/s3torchconnectorclient/rust/src/python_structs/py_head_object_result.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * // SPDX-License-Identifier: BSD
+ */
+
+use mountpoint_s3_client::types::HeadObjectResult;
+use pyo3::types::PyTuple;
+use pyo3::{pyclass, pymethods};
+use pyo3::{Bound, ToPyObject};
+use pyo3::{IntoPy, PyResult};
+
+use crate::python_structs::py_restore_status::PyRestoreStatus;
+use crate::PyRef;
+
+#[pyclass(
+    name = "HeadObjectResult",
+    module = "s3torchconnectorclient._mountpoint_s3_client",
+    frozen
+)]
+#[derive(Debug, Clone)]
+pub struct PyHeadObjectResult {
+    #[pyo3(get)]
+    etag: String,
+    #[pyo3(get)]
+    size: u64,
+    #[pyo3(get)]
+    last_modified: i64,
+    #[pyo3(get)]
+    storage_class: Option<String>,
+    #[pyo3(get)]
+    restore_status: Option<PyRestoreStatus>,
+}
+
+impl PyHeadObjectResult {
+    pub(crate) fn from_head_object_result(head_object_result: HeadObjectResult) -> Self {
+        PyHeadObjectResult::new(
+            head_object_result.etag.into_inner(),
+            head_object_result.size,
+            head_object_result.last_modified.unix_timestamp(),
+            head_object_result.storage_class,
+            head_object_result
+                .restore_status
+                .map(PyRestoreStatus::from_restore_status),
+        )
+    }
+}
+
+#[pymethods]
+impl PyHeadObjectResult {
+    #[new]
+    #[pyo3(signature = (etag, size, last_modified, storage_class=None, restore_status=None))]
+    pub fn new(
+        etag: String,
+        size: u64,
+        last_modified: i64,
+        storage_class: Option<String>,
+        restore_status: Option<PyRestoreStatus>,
+    ) -> Self {
+        Self {
+            etag,
+            size,
+            last_modified,
+            storage_class,
+            restore_status,
+        }
+    }
+
+    pub fn __getnewargs__(slf: PyRef<'_, Self>) -> PyResult<Bound<'_, PyTuple>> {
+        let py = slf.py();
+        let state = [
+            slf.etag.to_object(py),
+            slf.size.to_object(py),
+            slf.last_modified.to_object(py),
+            slf.storage_class.to_object(py),
+            slf.restore_status.clone().into_py(py),
+        ];
+        Ok(PyTuple::new_bound(py, state))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{:?}", self)
+    }
+}


### PR DESCRIPTION
## Description
Consume changes from mountpoint-s3-client. Changes contains support for dots in bucket name for COPY operation that was introduced in CRT.

## Additional context
Internal S3Client now returns `HeadObjectResult` instead of `ObjectInfo`. The only difference is that `HeadObjectResult` doesn't have `key` field.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
#295

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
