### PR TITLE
Remove obsolete parameter

### DIFF
--- a/s3torchbenchmarking/src/s3torchbenchmarking/datagen.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/datagen.py
@@ -212,7 +212,6 @@ def build_consumers(
             target=consumer,
             name=f"Uploader-{i}",
             kwargs={
-                "identifier": i,
                 "queue": queue,
                 "activity": lambda sample: Utils.upload_to_s3(
                     region=region,


### PR DESCRIPTION
## Description
Remove obsolete parameter `identifier`, as `consumer` method is not expected it anymore.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
#301

## Testing
Run s3torch-datagen

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
