### PR TITLE
Remove dependency on mountpoint-s3-crt and update MP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## TBD
+## ## v1.3.2 (February 5, 2025)
 
 ### New features
 * Consume mountpoint-s3-client changes with support for dots in bucket name for COPY operation introduced in CRT (#300)
 * Escape special characters in rename operation (#297)
+* Handle torch.load changes in PyTorch 2.6 (#306)
+* Remove dependency on mountpoint-s3-crt (#307)
 
 ### Breaking changes
 * Internal S3Client now returns `HeadObjectResult` instead of `ObjectInfo`. The only difference is that `HeadObjectResult` doesn't have `key` field. 

--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -137,9 +137,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "jobserver",
  "libc",
@@ -657,9 +657,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgit2-sys"
@@ -709,9 +709,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "matchers"
@@ -765,9 +765,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8676f5a43b1f347642d6f96bdb44172173ec9bb652b61fc9ff88da35ce11fb97"
+checksum = "f534991fc5aaa22c3a5dee34ee1f412b47dcfe2ad8a5bba86c3adf597fa3e5c6"
 dependencies = [
  "async-io",
  "async-lock",
@@ -780,7 +780,6 @@ dependencies = [
  "md-5",
  "metrics",
  "mountpoint-s3-crt",
- "mountpoint-s3-crt-sys",
  "percent-encoding",
  "pin-project",
  "platform-info",
@@ -797,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8468ebaaf2144abb5127ca6a3725cfc0227ef4687b464df7759ddad2aa722b0f"
+checksum = "962e660ead7b90cb5f3baf65ece1da8ea506ae82fff87a9ad6fc9c5e58dbfeac"
 dependencies = [
  "futures",
  "libc",
@@ -812,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743fc5652ecaa894bf3ed5e59d2404a2f1e5fc2274f148e31b90f2476a629a92"
+checksum = "ac583f5a0056e8bc54fc11046b97c7fc0475a6b25920b0665010fafc7926a03a"
 dependencies = [
  "bindgen",
  "cc",
@@ -887,18 +886,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -925,9 +924,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "platform-info"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91077ffd05d058d70d79eefcd7d7f6aac34980860a7519960f7913b6563a8c3a"
+checksum = "7539aeb3fdd8cb4f6a331307cf71a1039cee75e94e8a71725b9484f4a0d9451a"
 dependencies = [
  "libc",
  "winapi",
@@ -1181,7 +1180,6 @@ dependencies = [
  "futures",
  "log",
  "mountpoint-s3-client",
- "mountpoint-s3-crt",
  "nix",
  "pyo3",
  "rusty-fork",
@@ -1212,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -18,8 +18,7 @@ built = "0.7"
 [dependencies]
 pyo3 = "0.22.4"
 futures = "0.3.28"
-mountpoint-s3-client = { version = "0.12.0", features = ["mock"] }
-mountpoint-s3-crt = "0.11.0"
+mountpoint-s3-client = { version = "0.13.0", features = ["mock"] }
 log = "0.4.20"
 tracing = { version = "0.1.40", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"]}

--- a/s3torchconnectorclient/rust/src/logger_setup.rs
+++ b/s3torchconnectorclient/rust/src/logger_setup.rs
@@ -3,7 +3,7 @@
  * // SPDX-License-Identifier: BSD
  */
 use crate::exception::python_exception;
-use mountpoint_s3_crt::common::rust_log_adapter::RustLogAdapter;
+use mountpoint_s3_client::config::RustLogAdapter;
 use pyo3::PyResult;
 use std::env;
 use tracing_subscriber::filter::EnvFilter;

--- a/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
+++ b/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
@@ -9,8 +9,7 @@ use mountpoint_s3_client::config::{
 use mountpoint_s3_client::types::{GetObjectParams, HeadObjectParams, PutObjectParams};
 use mountpoint_s3_client::user_agent::UserAgent;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_crt::common::allocator::Allocator;
-use mountpoint_s3_crt::common::uri::Uri;
+use mountpoint_s3_client::config::{Allocator, Uri};
 use nix::unistd::Pid;
 use pyo3::types::PyTuple;
 use pyo3::{pyclass, pymethods, Bound, PyRef, PyResult, ToPyObject};


### PR DESCRIPTION
## Description
Remove dependency on mountpoint-s3-crt by consuming new version (0.13.0) of mountpoint_s3_client


- [x] I have updated the CHANGELOG or README if appropriate

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
