### PR TITLE
New work around for fork with multithread from CRT

### DIFF
--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -51,7 +51,8 @@ lightning = [
 
 lightning-tests = [
     "s3torchconnector[lightning]",
-    "s3fs"
+    "s3fs",
+    "torchmetrics != 1.7.0",
 ]
 
 dcp = [

--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -17,7 +17,7 @@ from s3torchconnectorclient._mountpoint_s3_client import (
     HeadObjectResult,
     ListObjectStream,
     GetObjectStream,
-    join_all_managed_threads
+    join_all_managed_threads,
 )
 
 from s3torchconnector._user_agent import UserAgent

--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -85,7 +85,15 @@ class S3Client:
             except Exception as e:
                 print(f"Join failed and error is {e}")
                 exit(-1)
-        os.register_at_fork(before=before_fork)
+
+        def after_in_parent():
+            global CRT_S3_CLIENT
+            assert CRT_S3_CLIENT is None
+            # After fork, we need to re-create the client in the parent process.
+            CRT_S3_CLIENT = self._client_builder()
+
+        os.register_at_fork(before=before_fork,
+                            after_in_parent=after_in_parent)
         assert CRT_S3_CLIENT is not None
         return CRT_S3_CLIENT
 

--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -86,10 +86,18 @@ class S3Client:
     @property
     def _client(self) -> MountpointS3Client:
         global CRT_S3_CLIENT
-        if self._client_pid is None or self._client_pid != os.getpid() or CRT_S3_CLIENT is None:
+        if (
+            self._client_pid is None
+            or self._client_pid != os.getpid()
+            or CRT_S3_CLIENT is None
+        ):
             # Acquire the lock to ensure thread-safety when creating the client.
             with _client_lock:
-                if self._client_pid is None or self._client_pid != os.getpid() or CRT_S3_CLIENT is None:
+                if (
+                    self._client_pid is None
+                    or self._client_pid != os.getpid()
+                    or CRT_S3_CLIENT is None
+                ):
                     # This double-check ensures that the client is only created once.
                     CRT_S3_CLIENT = self._client_builder()
                     self._client_pid = os.getpid()

--- a/s3torchconnector/tst/e2e/test_mountpoint_client_parallel_access.py
+++ b/s3torchconnector/tst/e2e/test_mountpoint_client_parallel_access.py
@@ -6,20 +6,17 @@ import pytest
 from s3torchconnector._s3client import S3Client
 from s3torchconnectorclient._mountpoint_s3_client import MountpointS3Client
 
+NATIVE_S3_CLIENT = None
+
 
 class S3ClientWithoutLock(S3Client):
     @property
     def _client(self) -> MountpointS3Client:
         global NATIVE_S3_CLIENT
-        if (
-            self._client_pid is None
-            or self._client_pid != os.getpid()
-            or NATIVE_S3_CLIENT is None
-        ):
+        if self._client_pid is None or self._client_pid != os.getpid():
             self._client_pid = os.getpid()
             # `MountpointS3Client` does not survive forking, so re-create it if the PID has changed.
             NATIVE_S3_CLIENT = self._client_builder()
-        assert NATIVE_S3_CLIENT is not None
         return NATIVE_S3_CLIENT
 
     def _client_builder(self):

--- a/s3torchconnector/tst/e2e/test_mountpoint_client_parallel_access.py
+++ b/s3torchconnector/tst/e2e/test_mountpoint_client_parallel_access.py
@@ -35,11 +35,9 @@ def access_client(client, error_event):
     try:
         if not error_event.is_set():
             client._client
-            print(
-                f"Successfully accessed by thread {threading.current_thread().name}")
+            print(f"Successfully accessed by thread {threading.current_thread().name}")
     except AssertionError as e:
-        print(
-            f"AssertionError in thread {threading.current_thread().name}: {e}")
+        print(f"AssertionError in thread {threading.current_thread().name}: {e}")
         error_event.set()
 
 
@@ -56,8 +54,7 @@ def test_multiple_thread_accessing_mountpoint_client_in_parallel_with_lock():
     print("Running test with lock...")
     client = S3ClientWithLock("us-west-2")
     if access_mountpoint_client_in_parallel(client):
-        pytest.fail(
-            "Test failed as AssertionError happened in one of the threads.")
+        pytest.fail("Test failed as AssertionError happened in one of the threads.")
 
 
 def access_mountpoint_client_in_parallel(client):

--- a/s3torchconnector/tst/e2e/test_mountpoint_client_parallel_access.py
+++ b/s3torchconnector/tst/e2e/test_mountpoint_client_parallel_access.py
@@ -17,6 +17,7 @@ class S3ClientWithoutLock(S3Client):
             self._client_pid = os.getpid()
             # `MountpointS3Client` does not survive forking, so re-create it if the PID has changed.
             NATIVE_S3_CLIENT = self._client_builder()
+        assert NATIVE_S3_CLIENT is not None
         return NATIVE_S3_CLIENT
 
     def _client_builder(self):
@@ -34,9 +35,11 @@ def access_client(client, error_event):
     try:
         if not error_event.is_set():
             client._client
-            print(f"Successfully accessed by thread {threading.current_thread().name}")
+            print(
+                f"Successfully accessed by thread {threading.current_thread().name}")
     except AssertionError as e:
-        print(f"AssertionError in thread {threading.current_thread().name}: {e}")
+        print(
+            f"AssertionError in thread {threading.current_thread().name}: {e}")
         error_event.set()
 
 
@@ -53,7 +56,8 @@ def test_multiple_thread_accessing_mountpoint_client_in_parallel_with_lock():
     print("Running test with lock...")
     client = S3ClientWithLock("us-west-2")
     if access_mountpoint_client_in_parallel(client):
-        pytest.fail("Test failed as AssertionError happened in one of the threads.")
+        pytest.fail(
+            "Test failed as AssertionError happened in one of the threads.")
 
 
 def access_mountpoint_client_in_parallel(client):

--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac583f5a0056e8bc54fc11046b97c7fc0475a6b25920b0665010fafc7926a03a"
+checksum = "9bcd7a1f6773475fe44811d29fd68d2cc88aaa6e8ffb94af90a17c93a36c0319"
 dependencies = [
  "bindgen",
  "cc",
@@ -1180,6 +1180,7 @@ dependencies = [
  "futures",
  "log",
  "mountpoint-s3-client",
+ "mountpoint-s3-crt-sys",
  "nix",
  "pyo3",
  "rusty-fork",

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -19,6 +19,7 @@ built = "0.7"
 pyo3 = "0.22.4"
 futures = "0.3.28"
 mountpoint-s3-client = { version = "0.13.0", features = ["mock"] }
+mountpoint-s3-crt-sys = { version = "0.12.1" }
 log = "0.4.20"
 tracing = { version = "0.1.40", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"]}

--- a/s3torchconnectorclient/python/src/s3torchconnectorclient/_mountpoint_s3_client.pyi
+++ b/s3torchconnectorclient/python/src/s3torchconnectorclient/_mountpoint_s3_client.pyi
@@ -145,3 +145,5 @@ class S3Exception(Exception):
     pass
 
 __version__: str
+
+def join_all_managed_threads(timeout_secs: float) -> None: ...

--- a/s3torchconnectorclient/rust/src/lib.rs
+++ b/s3torchconnectorclient/rust/src/lib.rs
@@ -42,7 +42,6 @@ fn make_lib(py: Python, mountpoint_s3_client: &Bound<'_, PyModule>) -> PyResult<
     mountpoint_s3_client.add_class::<PyRestoreStatus>()?;
     mountpoint_s3_client.add("S3Exception", py.get_type_bound::<S3Exception>())?;
     mountpoint_s3_client.add("__version__", build_info::FULL_VERSION)?;
-    // Inside create_module function
     mountpoint_s3_client.add_function(wrap_pyfunction!(
         join_all_managed_threads,
         mountpoint_s3_client

--- a/s3torchconnectorclient/rust/src/lib.rs
+++ b/s3torchconnectorclient/rust/src/lib.rs
@@ -7,11 +7,12 @@ use crate::exception::S3Exception;
 use crate::get_object_stream::GetObjectStream;
 use crate::list_object_stream::ListObjectStream;
 use crate::mock_client::PyMockClient;
+use crate::mountpoint_s3_client::join_all_managed_threads;
 use crate::mountpoint_s3_client::MountpointS3Client;
 use crate::put_object_stream::PutObjectStream;
+use crate::python_structs::py_head_object_result::PyHeadObjectResult;
 use crate::python_structs::py_list_object_result::PyListObjectResult;
 use crate::python_structs::py_object_info::PyObjectInfo;
-use crate::python_structs::py_head_object_result::PyHeadObjectResult;
 use crate::python_structs::py_restore_status::PyRestoreStatus;
 use pyo3::prelude::*;
 
@@ -41,5 +42,11 @@ fn make_lib(py: Python, mountpoint_s3_client: &Bound<'_, PyModule>) -> PyResult<
     mountpoint_s3_client.add_class::<PyRestoreStatus>()?;
     mountpoint_s3_client.add("S3Exception", py.get_type_bound::<S3Exception>())?;
     mountpoint_s3_client.add("__version__", build_info::FULL_VERSION)?;
+    // Inside create_module function
+    mountpoint_s3_client.add_function(wrap_pyfunction!(
+        join_all_managed_threads,
+        mountpoint_s3_client
+    )?)?;
+
     Ok(())
 }

--- a/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
+++ b/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
@@ -80,7 +80,7 @@ pub fn join_all_managed_threads(py: Python<'_>, timeout_secs: f64) -> PyResult<(
 
         aws_thread_set_managed_join_timeout_ns(timeout_ns);
 
-        // Release the GIL while waiting for other threads to join, which may acquire GIL.
+        // Release the GIL while waiting for other threads to join, which may acquire GIL, to avoid deadlock
         let result = py.allow_threads(|| aws_thread_join_all_managed());
 
         if result != 0 {

--- a/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
+++ b/s3torchconnectorclient/rust/src/mountpoint_s3_client.rs
@@ -10,10 +10,7 @@ use mountpoint_s3_client::config::{Allocator, Uri};
 use mountpoint_s3_client::types::{GetObjectParams, HeadObjectParams, PutObjectParams};
 use mountpoint_s3_client::user_agent::UserAgent;
 use mountpoint_s3_client::{ObjectClient, S3CrtClient};
-use mountpoint_s3_crt_sys::{
-    aws_last_error, aws_thread_join_all_managed, aws_thread_set_managed_join_timeout_ns,
-};
-use nix::unistd::Pid;
+use mountpoint_s3_crt_sys::{aws_thread_join_all_managed, aws_thread_set_managed_join_timeout_ns};
 use pyo3::marker::Python;
 use pyo3::types::PyTuple;
 use pyo3::{pyclass, pyfunction, pymethods, Bound, PyErr, PyRef, PyResult, ToPyObject};
@@ -52,8 +49,6 @@ pub struct MountpointS3Client {
     user_agent_prefix: String,
     #[pyo3(get)]
     endpoint: Option<String>,
-
-    owner_pid: Pid,
 }
 
 /// Waits for all managed CRT threads to complete, with a specified timeout.
@@ -259,7 +254,6 @@ impl MountpointS3Client {
             client: Arc::new(MountpointS3ClientInnerImpl::new(client)),
             user_agent_prefix,
             endpoint,
-            owner_pid: nix::unistd::getpid(),
         }
     }
 }


### PR DESCRIPTION
## Description
Previously, since the underlying CRT client has multiple background threads, there are couple hacks have done to workaround the fork issue. **Notes: overall, fork with multi-threading is not encouraged and not well supported.**
1. check the PID to make sure every process creates its own s3 client
2. If the client was not created by the current process, leave the client in memory to avoid the clean up steps try to invoke background threads already gone.

Well, it works **mostly**.
CRT has some global state related to threads (There may be more than what I listed, I just listed what I have found so far)
1. https://github.com/awslabs/aws-c-common/pull/1181 for more details
2. https://github.com/awslabs/aws-c-common/blob/main/source/thread_shared.c#L16, there is a global mutex a background thread can grab when it finises running. So, if the fork happens when one background threads holding the lock, that lock will be a dead lock forever for the subprocess.

Given the findings above, a _better_ workaround is to drop the CRT S3 client and then wait for CRT background threads to join, which will at least get around the two findings listed above. Printout warnings for user about the potential risk.

THIS IS JUST A PROVE OF CONCEPT, feel free to take over the branch 🙇‍♂️ 

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->


- [ ] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->


## Testing
<!-- Please describe how these changes were tested. -->

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
