### PR TITLE
Consume mountpoint-s3-client v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Introducing support of FSDP in DCP benchmark (#313)
 * Exposing max_attempts setting through S3ClientConfig and adding support of S3ClientConfig to DCP
 
+### Bug fixes
+* Consume mountpoint-s3-client changes for race condition on GET request path, that may lead to an empty response 
+
 ### Breaking changes
 * No breaking changes. 
 

--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -765,9 +765,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f534991fc5aaa22c3a5dee34ee1f412b47dcfe2ad8a5bba86c3adf597fa3e5c6"
+checksum = "4b179ceb7b3c2bbcae3ec943ec86df4f2e1466d1bafacb4367137344a565ec60"
 dependencies = [
  "async-io",
  "async-lock",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962e660ead7b90cb5f3baf65ece1da8ea506ae82fff87a9ad6fc9c5e58dbfeac"
+checksum = "29204a541b2b772cc093ce14fb03e04698ae5cf3b7494cf850a1995ea2a13f2f"
 dependencies = [
  "futures",
  "libc",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bcd7a1f6773475fe44811d29fd68d2cc88aaa6e8ffb94af90a17c93a36c0319"
+checksum = "54893d1531c8bcef7345fd3e75d559b106097472b058b77d81f1ccd2ca2c451b"
 dependencies = [
  "bindgen",
  "cc",

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -18,8 +18,8 @@ built = "0.7"
 [dependencies]
 pyo3 = "0.24.1"
 futures = "0.3.28"
-mountpoint-s3-client = { version = "0.13.0", features = ["mock"] }
-mountpoint-s3-crt-sys = { version = "0.12.1" }
+mountpoint-s3-client = { version = "0.13.2", features = ["mock"] }
+mountpoint-s3-crt-sys = { version = "0.13.0" }
 log = "0.4.20"
 tracing = { version = "0.1.40", default-features = false, features = ["std", "log"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"]}


### PR DESCRIPTION
## Description
Consume mountpoint-s3-client changes for race condition on GET request path, that may lead to an empty response.

## Additional context
Race condition on get_object path https://github.com/awslabs/mountpoint-s3/issues/1331

---

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
PIL UnidentifiedImageError training with higher 'num_workers' #293

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
