### PR TITLE
Workflow/integration test improvements

### DIFF
--- a/.github/workflows/generate_third_party_licenses.yml
+++ b/.github/workflows/generate_third_party_licenses.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   generate_third_party_licenses:
     name: Generate NOTICE_DEFAULT file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     outputs:
       artifact_name: ${{ steps.artifact_name.outputs.artifact_name }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -111,7 +111,7 @@ jobs:
 
   build_source_wheels:
     name: Build source wheels for ${{ matrix.build_target }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: generate_third_party_licenses
     strategy:
       matrix:

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "torch >= 2.0.1, != 2.5.0",
+    "torch >= 2.0.1, < 2.7.0, != 2.5.0",
     "s3torchconnectorclient == 1.4.0",
 ]
 

--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -107,3 +107,14 @@ test-command = [
     "CI_STORAGE_CLASS='' CI_REGION=${S3_REGION} CI_BUCKET=${S3_BUCKET} CI_PREFIX=${S3_PREFIX} CI_CUSTOM_ENDPOINT_URL=${S3_CUSTOM_ENDPOINT_URL} pytest -s {package}/../s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py",
     "AWS_DEFAULT_REGION=${S3_EXPRESS_REGION} CI_STORAGE_CLASS=EXPRESS_ONEZONE CI_REGION=${S3_EXPRESS_REGION} CI_BUCKET=${S3_EXPRESS_BUCKET} CI_PREFIX=${S3_PREFIX} CI_CUSTOM_ENDPOINT_URL='' pytest -s {package}/../s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py",
 ]
+
+[[tool.cibuildwheel.overrides]]
+# Using CPython 3.12.9 for MacOS to mitigate integration test hanging issue
+# Python is unable to cleanup hanging multiprocessing resource tracker processes in test_multiprocess_dataloading.py
+# See similar issue in: https://github.com/pytorch/pytorch/issues/153050
+select = "cp312-macosx*"
+before-all = [
+    "curl -o /tmp/Python3129.pkg https://www.python.org/ftp/python/3.12.9/python-3.12.9-macos11.pkg", 
+    "sudo installer -pkg /tmp/Python3129.pkg -target /",
+    "sh '/Applications/Python 3.12/Install Certificates.command'"
+]


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Updates CI/CD infrastructure and adds version constraints to address test stability:

1. Update GitHub Actions runners to ubuntu-24.04
   - Changed runner image from ubuntu-20.04 to ubuntu-24.04 for license generation and wheel build jobs. 
   - Addresses scheduled Ubuntu 20.04 deprecation (related issue below)
2. Temporarily cap PyTorch < 2.7.0
   - Temporarily restricted PyTorch version to below 2.7.0 to address integration test failures
3. Pin MacOS Python 3.12.9 
   - Mitigates resource tracker process cleanup issues in tests arising from Python 3.12.10 update 
   (related issue below)

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

No breaking changes introduced. The PyTorch version cap is temporary.

- [X] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
- Ubuntu 20.04 deprecation: actions/runner-images#11101
- Similar Python 3.12.10 hanging issue: pytorch/pytorch#153050

## Testing
<!-- Please describe how these changes were tested. -->
- Verified MacOS tests complete successfully with Python 3.12.9 (both x86 and arm)
- Confirmed builds work on ubuntu-24.04 runners
- Integration tests pass with PyTorch < 2.7.0 constraint

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
