### PR TITLE
Support PyTorch 2.7.0

### DIFF
--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -64,6 +64,7 @@ dcp = [
 dcp-test = [
     "s3torchconnector[dcp]",
     "pytest",
+    "importlib_metadata; python_version == '3.9'",
 ]
 
 [tool.setuptools.packages]

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "torch >= 2.0.1, < 2.7.0, != 2.5.0",
+    "torch >= 2.0.1, != 2.5.0",
     "s3torchconnectorclient == 1.4.0",
 ]
 


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->


Address PyTorch 2.7.0 compatibility issues:

1. Add importlib_metadata dependency for Python 3.9
   - Required by PyTorch 2.7.0 for e2e tests on Python 3.9
2. Improve S3Writer thread safety
   - Add lock to prevent multiple/concurrent stream closures
   - Add unit tests to verify thread-safe behavior

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

No breaking changes introduced.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

- Added unit tests verifying thread-safe close() behavior:
  - Multiple sequential close() calls
  - Concurrent close() calls from multiple threads
- Verified e2e tests pass on Python 3.9 with PyTorch 2.7.0

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
