### PR TITLE
fix: resolve DCP test hanging and distributed test errors

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -88,7 +88,14 @@ jobs:
           CI_REGION=${{ matrix.test-run.region }} \
           CI_BUCKET=${{ matrix.test-run.bucket }} \
           CI_STORAGE_CLASS=${{ matrix.test-run.storage-class }} \
-          pytest s3torchconnector/tst/e2e --ignore-glob '*/**/test_e2e_s3_lightning_checkpoint.py' --ignore-glob '*/**/dcp' -n auto
+          pytest s3torchconnector/tst/e2e --ignore-glob '*/**/test_e2e_s3_lightning_checkpoint.py' --ignore-glob '*/**/dcp' --ignore-glob '*/**/test_distributed_training.py' -n auto
+
+      - name: s3torchconnector ${{ matrix.test-run.name }} distributed training integration tests
+        run: |
+          CI_REGION=${{ matrix.test-run.region }} \
+          CI_BUCKET=${{ matrix.test-run.bucket }} \
+          CI_STORAGE_CLASS=${{ matrix.test-run.storage-class }} \
+          pytest s3torchconnector/tst/e2e/test_distributed_training.py
 
       - name: Install Lightning dependency
         run: |
@@ -110,7 +117,7 @@ jobs:
           CI_REGION=${{ matrix.test-run.region }} \
           CI_BUCKET=${{ matrix.test-run.bucket }} \
           CI_STORAGE_CLASS=${{ matrix.test-run.storage-class }} \
-          pytest s3torchconnector/tst/e2e/dcp -n auto
+          pytest s3torchconnector/tst/e2e/dcp
 
       - name: s3torchconnectorclient ${{ matrix.test-run.name }} integration tests
         run: |

--- a/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
+++ b/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
@@ -24,13 +24,19 @@ def generate_random_port():
 
 
 def setup(rank, world_size, port):
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = port
-    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    dist.init_process_group(
+        backend="gloo",
+        world_size=world_size,
+        rank=rank,
+        init_method=f"tcp://127.0.0.1:{port}",
+    )
 
 
 def cleanup():
-    dist.destroy_process_group()
+    # Synchronization point: Barrier ensures all process groups reach this point
+    dist.barrier()
+    if dist.is_initialized():
+        dist.destroy_process_group()
 
 
 def run(


### PR DESCRIPTION

## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Two issues were addressed in this PR:
1. DCP e2e tests were hanging in Github Actions
2. Distributed integration tests were intermittently returning Bad Request errors

DCP issue fix:
- Isolated process group initialization with explicit TCP arguments
- Added barrier synchronization point to ensure all processes complete before cleanup occurs

Using sequential runs:
- Removed parallel execution (-n auto) for both multi-process tests

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->
DCP Issue:
In [`test_e2e_s3_file_system.py`](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py), `multi_process_dcp_save_load()` spawns multiple processes to execute `run()`. Environment-based process group initialization could lead to shared state and port conflicts, and a race condition occurs when faster processes destroyed shared process group in `cleanup()`, leading to a hang. 

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
DCP e2e test hang: [[Github Run]](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/14204521787/job/39801176919)
Distributed training error: [[Github Run]](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/14909256523/job/41879209594)

## Testing
<!-- Please describe how these changes were tested. -->
- Reproduced issue with a t2.large EC2 instance to mimic [Github-hosted Runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). 
- Verified fix by running integration tests multiple times on EC2 instance
- Verified that sequential runs pass integration tests. 

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
