### PR TITLE
fix: prevent stream closure on exceptions in S3Writer

### DIFF
--- a/s3torchconnector/src/s3torchconnector/s3writer.py
+++ b/s3torchconnector/src/s3torchconnector/s3writer.py
@@ -4,8 +4,11 @@
 import io
 from typing import Union
 import threading
+import logging
 
 from s3torchconnectorclient._mountpoint_s3_client import PutObjectStream
+
+logger = logging.getLogger(__name__)
 
 
 class S3Writer(io.BufferedIOBase):
@@ -22,7 +25,16 @@ class S3Writer(io.BufferedIOBase):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
+        """Close stream on normal exit, log any exceptions that occurred."""
+        if exc_type is not None:
+            try:
+                logger.info(
+                    f"Exception occurred before closing stream: {exc_type.__name__}: {exc_val}"
+                )
+            except:
+                pass
+        else:
+            self.close()
 
     def write(
         self,

--- a/s3torchconnector/tst/unit/test_s3writer.py
+++ b/s3torchconnector/tst/unit/test_s3writer.py
@@ -87,3 +87,25 @@ def test_concurrent_close_calls():
 
     MOCK_STREAM.close.assert_called_once()
     assert writer._closed
+
+
+def test_exit_without_exception():
+    """Test __exit__ method when no exception occurs."""
+    MOCK_STREAM.reset_mock()
+
+    writer = S3Writer(MOCK_STREAM)
+    writer.__exit__(None, None, None)
+
+    MOCK_STREAM.close.assert_called_once()
+
+
+def test_exit_with_exception(caplog):
+    """Test __exit__ method when an exception occurs."""
+    MOCK_STREAM.reset_mock()
+
+    writer = S3Writer(MOCK_STREAM)
+    test_exception = ValueError("Test exception")
+    writer.__exit__(ValueError, test_exception, None)
+
+    # Stream should not be closed on exception
+    MOCK_STREAM.close.assert_not_called()


### PR DESCRIPTION

## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

This fix will prevent stream errors from being masked by closing S3Writer, by
- Not closing stream in S3Writer `__exit__` on exception
- Also logging exception to allow errors to gain extra visibility


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

Previously, when an exception occurred during S3 operations, attempting to close the stream would generate a "Client error: Internal S3 client error" message, masking the original error. This fix would allow more more error visibility by not closing the stream on exceptions.

No breaking changes introduced. 

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->
Added unit tests to verify:
- Normal exit properly closes stream
- Exception cases will not close stream.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
