### PR TITLE
fix: consume mountpoint-s3-client 0.14.1

### DIFF
--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -130,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
 name = "cc"
 version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,9 +784,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mountpoint-s3-client"
-version = "0.13.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7382cc35ec547be84ee20747b2f00cdd39092d917c5b98daf7c2818c92eea6a"
+checksum = "f5e37ef9da1062722e6d23a474efb2536dd8132f3198e614f1980bcdb123e696"
 dependencies = [
  "async-io",
  "async-lock",
@@ -788,6 +794,7 @@ dependencies = [
  "auto_impl",
  "base64ct",
  "built",
+ "bytes",
  "const_format",
  "futures",
  "md-5",
@@ -809,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29204a541b2b772cc093ce14fb03e04698ae5cf3b7494cf850a1995ea2a13f2f"
+checksum = "1223bf847213d68f0d4052f0b46f05a67894a9d2b9c4a651c1fd4f9fb00340c8"
 dependencies = [
  "futures",
  "libc",
@@ -824,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "mountpoint-s3-crt-sys"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54893d1531c8bcef7345fd3e75d559b106097472b058b77d81f1ccd2ca2c451b"
+checksum = "5aeebbc05066659d991158b72aefaeee36898d6fe3410f894ad5ff9b9762ec91"
 dependencies = [
  "bindgen",
  "cc",

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -18,7 +18,7 @@ built = "0.7"
 [dependencies]
 pyo3 = "0.24.1"
 futures = "0.3.28"
-mountpoint-s3-client = { version = "0.13.3", features = ["mock"] }
+mountpoint-s3-client = { version = "0.14.1", features = ["mock"] }
 mountpoint-s3-crt-sys = { version = "0.13.0" }
 log = "0.4.20"
 tracing = { version = "0.1.40", default-features = false, features = ["std", "log"] }

--- a/s3torchconnectorclient/rust/src/get_object_stream.rs
+++ b/s3torchconnectorclient/rust/src/get_object_stream.rs
@@ -5,6 +5,7 @@
 
 use pyo3::types::PyBytes;
 use pyo3::{pyclass, pymethods, Bound, PyRef, PyRefMut, PyResult};
+use mountpoint_s3_client::types::GetBodyPart;
 
 use crate::exception::S3Exception;
 use crate::mountpoint_s3_client_inner::MPGetObjectClosure;
@@ -45,7 +46,7 @@ impl GetObjectStream {
         let body_part = (slf.next_part)(py)?;
         match body_part {
             None => Ok(None),
-            Some((offset, data)) => {
+            Some(GetBodyPart { offset, data }) => {
                 if offset != slf.offset {
                     return Err(S3Exception::new_err(
                         "Data from S3 was returned out of order!",

--- a/s3torchconnectorclient/rust/src/mountpoint_s3_client_inner.rs
+++ b/s3torchconnectorclient/rust/src/mountpoint_s3_client_inner.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use futures::executor::block_on;
 use futures::TryStreamExt;
-use mountpoint_s3_client::types::{CopyObjectParams, GetObjectParams, HeadObjectParams, ListObjectsResult, PutObjectParams};
+use mountpoint_s3_client::types::{GetBodyPart, CopyObjectParams, GetObjectParams, HeadObjectParams, ListObjectsResult, PutObjectParams};
 use mountpoint_s3_client::ObjectClient;
 use pyo3::{PyResult, Python};
 
@@ -17,7 +17,7 @@ use crate::put_object_stream::PutObjectStream;
 use crate::python_structs::py_head_object_result::PyHeadObjectResult;
 
 pub type MPGetObjectClosure =
-    Box<dyn FnMut(Python) -> PyResult<Option<(u64, Box<[u8]>)>> + Send + Sync>;
+    Box<dyn FnMut(Python) -> PyResult<Option<GetBodyPart>> + Send + Sync>;
 
 /// We need an extra trait here, as pyo3 doesn't support structs with generics.
 /// However, it does allow dynamic traits. We can't ues `ObjectClient` itself, as that requires


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
Update to mountpoint-s3-client v0.14.1 to address CRT timeout issues and adapt to API changes:
- Include aws-c-s3 first byte timeout fix (awslabs/aws-c-s3/pull/461)
- Update get_object functions to use new GetBodyPart type (awslabs/mountpoint-s3/pull/1348)

This addresses AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT CRT error.


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
- CRT timeout fix: awslabs/aws-c-s3#461
- GetBodyPart API changes: awslabs/mountpoint-s3#1348

## Testing
<!-- Please describe how these changes were tested. -->
- Integration tests pass

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
