### PR TITLE
feat: add Python version to user agent string

### DIFF
--- a/s3torchconnector/src/s3torchconnector/_user_agent.py
+++ b/s3torchconnector/src/s3torchconnector/_user_agent.py
@@ -1,7 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 from typing import List, Optional
-import sys
+import platform
 
 from ._version import __version__
 
@@ -12,8 +12,14 @@ class UserAgent:
     def __init__(self, comments: Optional[List[str]] = None):
         if comments is not None and not isinstance(comments, list):
             raise ValueError("Argument comments must be a List[str]")
-        python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-        self._user_agent_prefix = f"{__package__}/{__version__} Python/{python_version}"
+
+        python_version = platform.python_version()
+        os_name = platform.system().lower()
+        if os_name == "darwin":
+            os_name = "macos"
+        os_version = platform.release()
+
+        self._user_agent_prefix = f"{__package__}/{__version__} ua/2.0 os/{os_name}#{os_version} lang/python#{python_version}"
         self._comments = comments or []
 
     @property

--- a/s3torchconnector/src/s3torchconnector/_user_agent.py
+++ b/s3torchconnector/src/s3torchconnector/_user_agent.py
@@ -12,14 +12,10 @@ class UserAgent:
     def __init__(self, comments: Optional[List[str]] = None):
         if comments is not None and not isinstance(comments, list):
             raise ValueError("Argument comments must be a List[str]")
-
         python_version = platform.python_version()
-        os_name = platform.system().lower()
-        if os_name == "darwin":
-            os_name = "macos"
-        os_version = platform.release()
-
-        self._user_agent_prefix = f"{__package__}/{__version__} ua/2.0 os/{os_name}#{os_version} lang/python#{python_version}"
+        self._user_agent_prefix = (
+            f"{__package__}/{__version__} ua/2.0 lang/python#{python_version}"
+        )
         self._comments = comments or []
 
     @property

--- a/s3torchconnector/src/s3torchconnector/_user_agent.py
+++ b/s3torchconnector/src/s3torchconnector/_user_agent.py
@@ -1,6 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 from typing import List, Optional
+import sys
 
 from ._version import __version__
 
@@ -11,7 +12,8 @@ class UserAgent:
     def __init__(self, comments: Optional[List[str]] = None):
         if comments is not None and not isinstance(comments, list):
             raise ValueError("Argument comments must be a List[str]")
-        self._user_agent_prefix = f"{__package__}/{__version__}"
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        self._user_agent_prefix = f"{__package__}/{__version__} Python/{python_version}"
         self._comments = comments or []
 
     @property

--- a/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
+++ b/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
@@ -21,6 +21,7 @@ from s3torchconnectorclient import __version__
 
 import os
 import random
+import platform
 
 from s3torchconnector.dcp.s3_prefix_strategy import RoundRobinPrefixStrategy
 from test_common import _list_folders_in_bucket
@@ -121,8 +122,15 @@ def multi_process_dcp_save_load(
     return s3_path_s3storagewriter
 
 
-def _verify_user_agent(s3fs: S3FileSystem):
-    expected_user_agent = f"s3torchconnector/{__version__} (dcp; {torch.__version__})"
+def _verify_user_agent(s3fs: S3FileSystem):    
+    python_version = platform.python_version()
+    os_name = platform.system().lower()
+    if os_name == "darwin":
+        os_name = "macos"
+    os_version = platform.release()
+    
+    expected_user_agent = f"s3torchconnector/{__version__} ua/2.0 os/{os_name}#{os_version} lang/python#{python_version} (dcp; {torch.__version__})"
+
     assert s3fs._client.user_agent_prefix == expected_user_agent
 
 

--- a/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
+++ b/s3torchconnector/tst/e2e/dcp/test_e2e_s3_file_system.py
@@ -122,15 +122,9 @@ def multi_process_dcp_save_load(
     return s3_path_s3storagewriter
 
 
-def _verify_user_agent(s3fs: S3FileSystem):    
+def _verify_user_agent(s3fs: S3FileSystem):
     python_version = platform.python_version()
-    os_name = platform.system().lower()
-    if os_name == "darwin":
-        os_name = "macos"
-    os_version = platform.release()
-    
-    expected_user_agent = f"s3torchconnector/{__version__} ua/2.0 os/{os_name}#{os_version} lang/python#{python_version} (dcp; {torch.__version__})"
-
+    expected_user_agent = f"s3torchconnector/{__version__} ua/2.0 lang/python#{python_version} (dcp; {torch.__version__})"
     assert s3fs._client.user_agent_prefix == expected_user_agent
 
 

--- a/s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py
+++ b/s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py
@@ -4,6 +4,7 @@ import lightning
 import pytest
 import random
 import torch
+import platform
 
 from pathlib import Path
 from typing import Dict, Any
@@ -258,7 +259,12 @@ def _verify_equal_state_dict(
 
 
 def _verify_user_agent(s3_lightning_checkpoint: S3LightningCheckpoint):
-    expected_user_agent = (
-        f"s3torchconnector/{__version__} (lightning; {lightning.__version__})"
-    )
+
+    python_version = platform.python_version()
+    os_name = platform.system().lower()
+    if os_name == "darwin":
+        os_name = "macos"
+    os_version = platform.release()
+
+    expected_user_agent = f"s3torchconnector/{__version__} ua/2.0 os/{os_name}#{os_version} lang/python#{python_version} (lightning; {lightning.__version__})"
     assert s3_lightning_checkpoint._client.user_agent_prefix == expected_user_agent

--- a/s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py
+++ b/s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py
@@ -259,12 +259,6 @@ def _verify_equal_state_dict(
 
 
 def _verify_user_agent(s3_lightning_checkpoint: S3LightningCheckpoint):
-
     python_version = platform.python_version()
-    os_name = platform.system().lower()
-    if os_name == "darwin":
-        os_name = "macos"
-    os_version = platform.release()
-
-    expected_user_agent = f"s3torchconnector/{__version__} ua/2.0 os/{os_name}#{os_version} lang/python#{python_version} (lightning; {lightning.__version__})"
+    expected_user_agent = f"s3torchconnector/{__version__} ua/2.0 lang/python#{python_version} (lightning; {lightning.__version__})"
     assert s3_lightning_checkpoint._client.user_agent_prefix == expected_user_agent

--- a/s3torchconnector/tst/unit/test_s3_client.py
+++ b/s3torchconnector/tst/unit/test_s3_client.py
@@ -2,7 +2,7 @@
 #  // SPDX-License-Identifier: BSD
 import logging
 import pytest
-import sys
+import platform
 
 from hypothesis import given, example
 from hypothesis.strategies import lists, text, integers, floats
@@ -18,10 +18,12 @@ TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key"
 TEST_REGION = "us-east-1"
 S3_URI = f"s3://{TEST_BUCKET}/{TEST_KEY}"
-PYTHON_VERSION = (
-    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-)
-DEFAULT_USER_AGENT = f"s3torchconnector/{__version__} Python/{PYTHON_VERSION}"
+PYTHON_VERSION = platform.python_version()
+OS_NAME = platform.system().lower()
+if OS_NAME == "darwin":
+    OS_NAME = "macos"
+OS_VERSION = platform.release()
+DEFAULT_USER_AGENT = f"s3torchconnector/{__version__} ua/2.0 os/{OS_NAME}#{OS_VERSION} lang/python#{PYTHON_VERSION}"
 
 KiB = 1 << 10
 MiB = 1 << 20

--- a/s3torchconnector/tst/unit/test_s3_client.py
+++ b/s3torchconnector/tst/unit/test_s3_client.py
@@ -19,11 +19,9 @@ TEST_KEY = "test-key"
 TEST_REGION = "us-east-1"
 S3_URI = f"s3://{TEST_BUCKET}/{TEST_KEY}"
 PYTHON_VERSION = platform.python_version()
-OS_NAME = platform.system().lower()
-if OS_NAME == "darwin":
-    OS_NAME = "macos"
-OS_VERSION = platform.release()
-DEFAULT_USER_AGENT = f"s3torchconnector/{__version__} ua/2.0 os/{OS_NAME}#{OS_VERSION} lang/python#{PYTHON_VERSION}"
+DEFAULT_USER_AGENT = (
+    f"s3torchconnector/{__version__} ua/2.0 lang/python#{PYTHON_VERSION}"
+)
 
 KiB = 1 << 10
 MiB = 1 << 20

--- a/s3torchconnector/tst/unit/test_s3_client.py
+++ b/s3torchconnector/tst/unit/test_s3_client.py
@@ -2,6 +2,7 @@
 #  // SPDX-License-Identifier: BSD
 import logging
 import pytest
+import sys
 
 from hypothesis import given, example
 from hypothesis.strategies import lists, text, integers, floats
@@ -17,6 +18,10 @@ TEST_BUCKET = "test-bucket"
 TEST_KEY = "test-key"
 TEST_REGION = "us-east-1"
 S3_URI = f"s3://{TEST_BUCKET}/{TEST_KEY}"
+PYTHON_VERSION = (
+    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+)
+DEFAULT_USER_AGENT = f"s3torchconnector/{__version__} Python/{PYTHON_VERSION}"
 
 KiB = 1 << 10
 MiB = 1 << 20
@@ -76,18 +81,15 @@ def test_copy_object_log(s3_client: S3Client, caplog):
 
 def test_s3_client_default_user_agent():
     s3_client = S3Client(region=TEST_REGION)
-    expected_user_agent = f"s3torchconnector/{__version__}"
-    assert s3_client.user_agent_prefix == expected_user_agent
-    assert s3_client._client.user_agent_prefix == expected_user_agent
+    assert s3_client.user_agent_prefix == DEFAULT_USER_AGENT
+    assert s3_client._client.user_agent_prefix == DEFAULT_USER_AGENT
 
 
 def test_s3_client_custom_user_agent():
     s3_client = S3Client(
         region=TEST_REGION, user_agent=UserAgent(["component/version", "metadata"])
     )
-    expected_user_agent = (
-        f"s3torchconnector/{__version__} (component/version; metadata)"
-    )
+    expected_user_agent = f"{DEFAULT_USER_AGENT} (component/version; metadata)"
     assert s3_client.user_agent_prefix == expected_user_agent
     assert s3_client._client.user_agent_prefix == expected_user_agent
 

--- a/s3torchconnector/tst/unit/test_user_agent.py
+++ b/s3torchconnector/tst/unit/test_user_agent.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from typing import List
+import sys
 
 import pytest
 
 from s3torchconnector._version import __version__
 from s3torchconnector._user_agent import UserAgent
 
-DEFAULT_PREFIX = f"s3torchconnector/{__version__}"
+PYTHON_VERSION = (
+    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+)
+DEFAULT_PREFIX = f"s3torchconnector/{__version__} Python/{PYTHON_VERSION}"
 
 
 @pytest.mark.parametrize(

--- a/s3torchconnector/tst/unit/test_user_agent.py
+++ b/s3torchconnector/tst/unit/test_user_agent.py
@@ -11,11 +11,7 @@ from s3torchconnector._version import __version__
 from s3torchconnector._user_agent import UserAgent
 
 PYTHON_VERSION = platform.python_version()
-OS_NAME = platform.system().lower()
-if OS_NAME == "darwin":
-    OS_NAME = "macos"
-OS_VERSION = platform.release()
-DEFAULT_PREFIX = f"s3torchconnector/{__version__} ua/2.0 os/{OS_NAME}#{OS_VERSION} lang/python#{PYTHON_VERSION}"
+DEFAULT_PREFIX = f"s3torchconnector/{__version__} ua/2.0 lang/python#{PYTHON_VERSION}"
 
 
 @pytest.mark.parametrize(

--- a/s3torchconnector/tst/unit/test_user_agent.py
+++ b/s3torchconnector/tst/unit/test_user_agent.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 from typing import List
-import sys
+import platform
 
 import pytest
 
 from s3torchconnector._version import __version__
 from s3torchconnector._user_agent import UserAgent
 
-PYTHON_VERSION = (
-    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-)
-DEFAULT_PREFIX = f"s3torchconnector/{__version__} Python/{PYTHON_VERSION}"
+PYTHON_VERSION = platform.python_version()
+OS_NAME = platform.system().lower()
+if OS_NAME == "darwin":
+    OS_NAME = "macos"
+OS_VERSION = platform.release()
+DEFAULT_PREFIX = f"s3torchconnector/{__version__} ua/2.0 os/{OS_NAME}#{OS_VERSION} lang/python#{PYTHON_VERSION}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

- Added Python version to user agent string to help track usage across Python versions
- Followed AWS SDK User Agent 2.0 formatting
- Updated unit tests and e2e tests (lightning and dcp)
Example: s3torchconnector/1.4.0 ua/2.0 lang/python#3.10.12 ...


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

Following RFC 9110 guidelines. 
No breaking changes - only updates existing user agent string format.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
AWS SDK User Agent Header - User Agent 2.0

## Testing
<!-- Please describe how these changes were tested. -->
- Verified integration tests pass

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
