### PR TITLE
provide profile as part of S3ClientConfig

### DIFF
--- a/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/_s3client.py
@@ -121,6 +121,7 @@ class S3Client:
         return MountpointS3Client(
             region=self._region,
             endpoint=self._endpoint,
+            profile=self._s3client_config.profile,
             user_agent_prefix=self._user_agent_prefix,
             throughput_target_gbps=self._s3client_config.throughput_target_gbps,
             part_size=self._s3client_config.part_size,

--- a/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
@@ -15,8 +15,10 @@ class S3ClientConfig:
         (max number of parts per upload is 10,000, minimum upload part size is 5 MiB).
         Part size must have values between 5MiB and 5GiB.
         8MiB by default (may change in future).
+    unsigned(bool): Set to true to disable signing S3 requests.
     force_path_style(bool): forceful path style addressing for S3 client.
-    max_attempts(int): amount of retry attempts for retrieable errors
+    max_attempts(int): amount of retry attempts for retrieable errors.
+    config(str): Profile name to use for S3 authentication.
     """
 
     throughput_target_gbps: float = 10.0
@@ -24,3 +26,4 @@ class S3ClientConfig:
     unsigned: bool = False
     force_path_style: bool = False
     max_attempts: int = 10
+    config: str = None

--- a/s3torchconnector/tst/unit/test_s3_client_config.py
+++ b/s3torchconnector/tst/unit/test_s3_client_config.py
@@ -13,12 +13,16 @@ def test_default():
     assert config.throughput_target_gbps == 10.0
     assert config.force_path_style is False
     assert config.max_attempts == 10
+    assert config.profile is None
 
 
 def test_enable_force_path_style():
     config = S3ClientConfig(force_path_style=True)
     assert config.force_path_style is True
 
+def test_change_profile():
+    config = S3ClientConfig(profile="test_profile")
+    assert config.profile == "test_profile"
 
 @given(part_size=integers(min_value=5 * MiB, max_value=5 * GiB))
 def test_part_size_setup(part_size: int):


### PR DESCRIPTION
## Description
Everything is ready to support custom S3 user profiles. We only need to allow passing it through the `S3ClientConfig` to the `MountpointS3Client`.

## Additional context
The rust implementation is already ready to accept a custom user provided profile - we only need to reveal it to the user as part of the `S3ClientConfig` configuration.


- [X] I have updated the CHANGELOG or README if appropriate


## Testing
I have tested this PR with a custom profile and everything worked as expected. This PR is really a 4 line change that could make a nice impact for specific use cases.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
