### PR TITLE
Updates compilers settings to support manylinux_2_28 images

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,6 +96,8 @@ jobs:
       # Run cibuildwheel manually, as the current runner uses setup-python
       # https://github.com/pypa/cibuildwheel/issues/1623
       - run: >
+          CIBW_MANYLINUX_X86_64_IMAGE=manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE=manylinux2014
           python -m pipx run
           cibuildwheel
           "s3torchconnectorclient"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ${{ matrix.builder.runner }}
     needs: generate_third_party_licenses
     strategy:
+      fail-fast: false
       matrix:
         python:
           - cp38
@@ -114,6 +115,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: generate_third_party_licenses
     strategy:
+      fail-fast: false
       matrix:
         build_target:
           - s3torchconnector

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,8 +96,6 @@ jobs:
       # Run cibuildwheel manually, as the current runner uses setup-python
       # https://github.com/pypa/cibuildwheel/issues/1623
       - run: >
-          CIBW_MANYLINUX_X86_64_IMAGE=manylinux2014
-          CIBW_MANYLINUX_AARCH64_IMAGE=manylinux2014
           python -m pipx run
           cibuildwheel
           "s3torchconnectorclient"

--- a/run_cibuildwheel_on_ec2.sh
+++ b/run_cibuildwheel_on_ec2.sh
@@ -31,4 +31,4 @@ export S3_EXPRESS_REGION=${EXPRESS_REGION_NAME}
 export S3_EXPRESS_BUCKET=${EXPRESS_BUCKET_NAME}
 export S3_CUSTOM_ENDPOINT_URL=${S3_CUSTOM_ENDPOINT_URL}
 
-CIBW_MANYLINUX_X86_64_IMAGE=manylinux2014 CIBW_MANYLINUX_AARCH64_IMAGE=manylinux2014 cibuildwheel --output-dir wheelhouse --platform linux s3torchconnectorclient
+cibuildwheel --output-dir wheelhouse --platform linux s3torchconnectorclient

--- a/run_cibuildwheel_on_ec2.sh
+++ b/run_cibuildwheel_on_ec2.sh
@@ -31,4 +31,4 @@ export S3_EXPRESS_REGION=${EXPRESS_REGION_NAME}
 export S3_EXPRESS_BUCKET=${EXPRESS_BUCKET_NAME}
 export S3_CUSTOM_ENDPOINT_URL=${S3_CUSTOM_ENDPOINT_URL}
 
-cibuildwheel --output-dir wheelhouse --platform linux s3torchconnectorclient
+CIBW_MANYLINUX_X86_64_IMAGE=manylinux2014 CIBW_MANYLINUX_AARCH64_IMAGE=manylinux2014 cibuildwheel --output-dir wheelhouse --platform linux s3torchconnectorclient

--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -77,20 +77,29 @@ skip = "*musllinux* *i686"
 
 [tool.cibuildwheel.linux]
 before-all = [
-  "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
-  "bash -c 'platform=$(uname -p); if [ \"$platform\" == \"aarch64\" ]; then sed -i \"s|centos/7|altarch/7|g\" /etc/yum.repos.d/*.repo; fi'",
-  "yum install -y fuse",
-  "yum install -y fuse-devel",
-  "yum install -y make",
-  "yum install -y git",
-  "yum install -y pkgconfig",
-  "yum install -y tar",
-  "yum install -y wget",
-  "yum install -y devtoolset-10-gcc",
-  "yum install -y devtoolset-10-gcc-c++",
-  "yum install -y llvm-toolset-7.0-clang"
+    "yum -y update",
+    "yum -y install openssl3 openssl3-devel",
+    "yum install -y gcc-toolset-10-gcc",
+    "yum install -y gcc-toolset-10-gcc-c++",
+    "yum install -y clang clang-devel llvm-toolset",
+
+    "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y",
+    "bash -c 'platform=$(uname -p); if [ \"$platform\" == \"aarch64\" ]; then sed -i \"s|centos/7|altarch/7|g\" /etc/yum.repos.d/*.repo; fi'",
+
+    "yum install -y fuse",
+    "yum install -y fuse-devel",
+    "yum install -y make",
+    "yum install -y git",
+    "yum install -y pkgconfig",
+    "yum install -y tar",
+    "yum install -y wget"
 ]
-environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/devtoolset-10/root/usr/bin:$HOME/.cargo/bin:$PATH", LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib", CC="/opt/rh/devtoolset-10/root/usr/bin/gcc", CXX="/opt/rh/devtoolset-10/root/usr/bin/g++" }
+
+[tool.cibuildwheel.linux.environment]
+PATH = "/usr/lib64/ccache:/usr/lib64/llvm:/opt/rh/gcc-toolset-10/root/usr/bin:$HOME/.cargo/bin:$PATH"
+LD_LIBRARY_PATH = "/usr/lib64/llvm:/opt/rh/gcc-toolset-10/root/usr/lib64:/opt/rh/gcc-toolset-10/root/usr/lib:$LD_LIBRARY_PATH"
+CC = "/opt/rh/gcc-toolset-10/root/usr/bin/gcc"
+CXX = "/opt/rh/gcc-toolset-10/root/usr/bin/g++"
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.12" }


### PR DESCRIPTION
## Description
Update build configuration for latest manylinux_2_28 images

The latest manylinux_2_28 images used for building wheels no longer support `devtoolset` and `llvm-toolset`. This PR updates our build configuration to use `gcc-toolset` and `clang` instead, ensuring compatibility with the most recent images.

Key changes:
- Replace `devtoolset` with `gcc-toolset-10`
- Replace `llvm-toolset` with the standard `clang` package
- Update environment variables and paths accordingly
- 
--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
