### PR TITLE
docs: update AWS profile docs, links, and grammar

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,8 +3,7 @@
 To develop `s3torchconnector`, you need to have Python, `pip` and `python-venv` installed. 
 
 `s3torchconnector` uses `s3torchconnectorclient` as the underlying S3 Connector. `s3torchconnectorclient` is a 
-Python wrapper around MountpointS3Client that uses S3 CRT to optimize performance of S3 read/write
-.
+Python wrapper around MountpointS3Client that uses S3 CRT to optimize performance of S3 read/write.
 Since MountpointS3Client is implemented in Rust, for development and building from source, you will need to install 
 `clang`, `cmake` and rust compiler (as detailed below). 
 
@@ -19,7 +18,7 @@ sudo apt install python3-pip
 ```shell
   git clone git@github.com:awslabs/s3-connector-for-pytorch.git
 ```
-#### Create  a Python virtual environment
+#### Create a Python virtual environment
 ```shell
   cd /path/to/your/project
   python3 -m venv virtual-env
@@ -154,7 +153,7 @@ Using S3ClientConfig you can set up the following parameters for the underlying 
 
 * `max_attempts(int)`: Number of retries for retriable errors
 
-For example this can be passed in like: 
+For example, this can be passed in like: 
 ```py
 from s3torchconnector import S3MapDataset, S3ClientConfig
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ see [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/
 
 To use `s3torchconnector`, AWS credentials must be provided through one of the following methods:
 
-- If you are using this library on an EC2 instance, specify an IAM role and then give the EC2 instance access to 
-that role.
-- Install and configure [`awscli`](https://aws.amazon.com/cli/) and run `aws configure`.
-- Set credentials in the AWS credentials profile file on the local system, located at: `~/.aws/credentials` 
-on Unix or macOS.
-- Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- Pass the name of the desired profile that you have configured in `~/.aws/config` and `~/.aws/credentials` to the `S3ClientConfig` object.
+- **EC2 Instance Role**: If you are using this library on an EC2 instance, specify an IAM role and then give the EC2 instance access to that role.
+- **AWS CLI**: Install and configure [`awscli`](https://aws.amazon.com/cli/) and run `aws configure`.
+- **AWS Credential Files**: Set credentials in the AWS credentials profile file on the local system, located at: `~/.aws/credentials` on Unix or macOS.
+- **Environment Variables**: Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+
+To use a specific AWS profile configured in `~/.aws/config` and `~/.aws/credentials`, you can either:
+
+- Set environment variable `AWS_PROFILE=custom-profile`, or 
+- Pass the profile name to the `S3ClientConfig` object, e.g. `S3ClientConfig(profile="custom-profile")`.
+
+For a more detailed configuration guide, see [AWS CLI docs](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html).
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install s3torchconnector
 ```
 
 Amazon S3 Connector for PyTorch supports pre-build wheels via Pip only for Linux and MacOS for now. For other platforms,
-see [DEVELOPMENT](DEVELOPMENT.md) for build instructions.
+see [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/DEVELOPMENT.md) for build instructions.
 
 ### Configuration
 
@@ -46,7 +46,7 @@ on Unix or macOS.
 ### Examples
 
 [API docs](http://awslabs.github.io/s3-connector-for-pytorch) are showing API of the public components. 
-End to end example of how to use `s3torchconnector` can be found under the [examples](examples) directory.
+End to end example of how to use `s3torchconnector` can be found under the [examples](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/examples) directory.
 
 #### Sample Examples
 
@@ -143,7 +143,7 @@ pip install s3torchconnector[dcp]
 ### Sample Example
 
 End-to-end examples for using distributed checkpoints with S3 Connector for PyTorch 
-can be found in the [examples/dcp](examples/dcp) directory.
+can be found in the [examples/dcp](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/examples/dcp) directory.
 
 ```py
 from s3torchconnector.dcp import S3StorageWriter, S3StorageReader
@@ -348,7 +348,7 @@ pip install s3torchconnector[lightning]
 
 ### Examples
 
-End to end examples for the Pytorch Lightning integration can be found in the [examples/lightning](examples/lightning)
+End to end examples for the Pytorch Lightning integration can be found in the [examples/lightning](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/examples/lightning)
 directory.
 
 ```py
@@ -488,11 +488,11 @@ For `S3ReaderConstructor` usage details, please refer to the [`S3ReaderConstruct
 
 ## Contributing
 
-We welcome contributions to Amazon S3 Connector for PyTorch. Please see [CONTRIBUTING](CONTRIBUTING.md) for more
+We welcome contributions to Amazon S3 Connector for PyTorch. Please see [CONTRIBUTING](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/CONTRIBUTING.md) for more
 information on how to report bugs or submit pull requests.
 
 ### Development
-See [DEVELOPMENT](DEVELOPMENT.md) for information about code style, development process, and guidelines.
+See [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/DEVELOPMENT.md) for information about code style, development process, and guidelines.
 
 ### Compatibility with other storage services
 S3 Connector for PyTorch delivers high throughput for PyTorch training jobs that access or store data in Amazon S3. 
@@ -507,9 +507,9 @@ If you discover a potential security issue in this project we ask that you notif
 ### Code of conduct
 
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for more details.
+See [CODE_OF_CONDUCT.md](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/CODE_OF_CONDUCT.md) for more details.
 
 ## License
 
-Amazon S3 Connector for PyTorch has a BSD 3-Clause License, as found in the [LICENSE](LICENSE) file.
+Amazon S3 Connector for PyTorch has a BSD 3-Clause License, as found in the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE) file.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Amazon S3, without first saving to local storage.
 pip install s3torchconnector
 ```
 
-Amazon S3 Connector for PyTorch supports pre-build wheels via Pip only for Linux and MacOS for now. For other platforms,
+Amazon S3 Connector for PyTorch supports pre-built wheels via Pip only for Linux and MacOS for now. For other platforms,
 see [DEVELOPMENT](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/DEVELOPMENT.md) for build instructions.
 
 ### Configuration
@@ -76,7 +76,7 @@ for item in iterable_dataset:
 # This process might take some time and may give the impression of being unresponsive.
 map_dataset = S3MapDataset.from_prefix(DATASET_URI, region=REGION)
 
-# Randomly access to an item in map_dataset.
+# Randomly access an item in map_dataset.
 item = map_dataset[0]
 
 # Learn about bucket, key, and content of the object
@@ -340,7 +340,7 @@ dataloader = DataLoader(dataset, sampler=sampler, num_workers=4)
 
 Amazon S3 Connector for PyTorch includes an integration for PyTorch Lightning, featuring S3LightningCheckpoint, an 
 implementation of Lightning's CheckpointIO. This allows users to make use of Amazon S3 Connector for PyTorch's S3 
-checkpointing functionality with Pytorch Lightning.
+checkpointing functionality with PyTorch Lightning.
 
 ### Getting Started
 
@@ -352,7 +352,7 @@ pip install s3torchconnector[lightning]
 
 ### Examples
 
-End to end examples for the Pytorch Lightning integration can be found in the [examples/lightning](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/examples/lightning)
+End to end examples for the PyTorch Lightning integration can be found in the [examples/lightning](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/examples/lightning)
 directory.
 
 ```py

--- a/s3torchbenchmarking/README.md
+++ b/s3torchbenchmarking/README.md
@@ -15,7 +15,7 @@ performance impact to the end-to-end training process.
     - Measure performance in data fetching and indexing
 2. **PyTorch's Distributed Checkpointing (DCP) benchmarks**
     - Assess our connector's performance versus PyTorch's default distributed checkpointing mechanism
-    - For detailed information, refer to the one of dedicated [DCP using DDP `README`](src/s3torchbenchmarking/dcp_ddp/README.md)
+    - For detailed information, refer to [DCP using DDP `README`](src/s3torchbenchmarking/dcp_ddp/README.md)
 or [DCP using FSDP `README`](src/s3torchbenchmarking/dcp_fsdp/README.md)
 3. **PyTorch Lightning Checkpointing benchmarks**
     - Evaluate our connector within the PyTorch Lightning framework
@@ -96,7 +96,7 @@ s3torch-datagen -n 100k --shard-size 128MiB --s3-bucket my-bucket --region us-ea
 ## Running the benchmarks
 
 You can run the different benchmarks by editing their corresponding config files, then running one of those shell
-script (specifically, you must provide a value for all keys marked with `???`):
+scripts (specifically, you must provide a value for all keys marked with `???`):
 
 ```shell
 # Dataset benchmarks
@@ -105,22 +105,24 @@ vim ./conf/dataset.yaml           # 1. edit config
 
 # PyTorch Checkpointing benchmarks
 vim ./conf/pytorch_checkpointing.yaml # 1. edit config
-./utils/run_checkpoints_benchmarks.sh # 2. run scenario
+./utils/run_checkpoint_benchmarks.sh # 2. run scenario
 
 # PyTorch Lightning Checkpointing benchmarks
 vim ./conf/lightning_checkpointing.yaml # 1. edit config
-./utils/run_lighning_benchmarks.sh      # 2. run scenario
+./utils/run_lightning_benchmarks.sh      # 2. run scenario
 
 # PyTorch’s Distributed Checkpointing (DCP) benchmarks
-vim ./conf/dcp.yaml           # 1. edit config
+vim ./conf/dcp_ddp.yaml           # 1. edit config
+vim ./conf/dcp_fsdp.yaml
 ./utils/run_dcp_ddp_benchmarks.sh # 2. run scenario
+./utils/run_dcp_fsdp_benchmarks.sh
 ```
 
 > [!NOTE]
 > Ensure the bucket is in the same region as the EC2 instance, to eliminate network latency effects in your
 > measurements.
 
-Each of those scripts rely on Hydra config files, located under the [`conf`](conf) directory. You may edit those as you
+Each of those scripts relies on Hydra config files, located under the [`conf`](conf) directory. You may edit those as you
 see fit to configure the runs: in particular, parameters under the `hydra.sweeper.params` path will create as many jobs
 as the cartesian product of those.
 
@@ -145,7 +147,7 @@ Benchmark results are organized as follows, inside a default `./multirun` direct
         │   └── job_results.json
         ├── 1
         │   ├── benchmark.log
-        │   └── job_resutls.json
+        │   └── job_results.json
         ├── multirun.yaml
         └── run_results.json
 ```
@@ -158,7 +160,7 @@ Each run directory contains job subdirectories (e.g., `0`, `1`, etc.), correspon
 
 ### Experiment reporting
 
-Experiments will report various metrics, such as throughput and processed time — the exact types vary per scenarios.
+Experiments will report various metrics, such as throughput and processed time — the exact types vary per scenario.
 Results are stored in two locations:
 
 1. In the job subdirectories:


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Changes:
- Document profile configurations explicitly
  - Include environment variable method to configure AWS profile, addressing issue https://github.com/awslabs/s3-connector-for-pytorch/issues/151
  - Add AWS CLI docs link for detailed configuration guide.
  - Made configuration options more visually distinct with bold headers
- Use absolute links instead of relative links in README (for [PyPI project description](https://pypi.org/project/s3torchconnector/))
- fix minor grammar / syntax / spelling / formatting errors, in READMEs and DEVELOPMENT docs.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

Related Issue: https://github.com/awslabs/s3-connector-for-pytorch/issues/151

## Testing
<!-- Please describe how these changes were tested. -->

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
