### PR TITLE
Experiment/dcp read patterns

### DIFF
--- a/s3torchconnector/src/s3torchconnector/dcp/s3_file_system.py
+++ b/s3torchconnector/src/s3torchconnector/dcp/s3_file_system.py
@@ -311,6 +311,9 @@ class S3StorageWriter(FileSystemWriter):
         self.sort_key = sort_key
 
         if self.sort_key:
+            logger.debug(
+                "Enabling custom tensor ordering for distributed checkpoint save"
+            )
             # Replace the original split function with ours that will sort tensors/weights
             import torch.distributed.checkpoint.filesystem as fs_module
             from functools import partial
@@ -407,6 +410,9 @@ class S3StorageReader(FileSystemReader):
 
     def prepare_local_plan(self, plan: LoadPlan) -> LoadPlan:
         # Sort items in plan based on their offset in checkpoints shards
+        logger.debug(
+            f"Ordering {len(plan.items)} distributed checkpoint items by storage offset for sequential access"
+        )
         plan.items.sort(key=lambda item: self.storage_data[item.storage_index].offset)
         return plan
 


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

> Note: Draft PR to run integration tests - not intended for production.

This PR adds logs to assist with DCP read pattern analyses. These changes add debug logs in:
- S3Reader classes (sequential and range_based), logging each read/readinto
  - Includes file name, process ID (pid), read type (read/readinto), current position, and read size.
- S3StorageReader read_data method (overriding [original read_data implementation](https://github.com/pytorch/pytorch/blob/5998cd4eaaf50d5a427f0b0ec14f2135e4a46723/torch/distributed/checkpoint/filesystem.py#L823))
  - for each tensor, log the filename, pid, tensor_type, storage offset, and storage length
  - Note: we extract only first part of tensor fqn as tensor_type to avoid disclosing full name of the tensor.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

**Debug Log examples:**

```
2025-07-24 12:44:20,394 [s3torchconnector.dcp.s3_file_system] [DEBUG] file=__4_6.distcp, pid=67316, type=tensor_storage_data, tensor_type=model, storage_offset=293092332, storage_length=8389788
2025-07-24 12:44:20,394 [s3torchconnector.dcp.s3_file_system] [DEBUG] file=__1_6.distcp, pid=67320, type=tensor_storage_data, tensor_type=model, storage_offset=427328940, storage_length=3228
2025-07-24 12:44:20,394 [s3torchconnector.dcp.s3_file_system] [DEBUG] file=__5_6.distcp, pid=67316, type=tensor_storage_data, tensor_type=model, storage_offset=293092332, storage_length=8389788
...
2025-07-24 12:45:00,262 [s3torchconnector.s3reader.sequential] [DEBUG] file=__0_5.distcp, pid=67321, type=readinto, position=157819290, size=30
2025-07-24 12:45:00,262 [s3torchconnector.s3reader.sequential] [DEBUG] file=__0_5.distcp, pid=67321, type=readinto, position=157819396, size=22544384
2025-07-24 12:45:00,263 [s3torchconnector.s3reader.sequential] [DEBUG] file=__0_5.distcp, pid=67314, type=read, position=368600424, size=4
2025-07-24 12:45:00,263 [s3torchconnector.s3reader.sequential] [DEBUG] file=__0_5.distcp, pid=67314, type=readinto, position=368600424, size=8
```

**Example script logging setup:**

```
# ----- logging setup -----
log_dir = "logs"
os.makedirs(log_dir, exist_ok=True)
timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
log_file = os.path.join(log_dir, f"dcp_read_patterns_{timestamp}.log")

logging.basicConfig(
    level=logging.DEBUG,
    format='%(asctime)s [%(name)s] [%(levelname)s] %(message)s',
    handlers=[
        logging.StreamHandler(sys.stdout),
        logging.FileHandler(log_file)
    ],
)

logger = logging.getLogger(__name__)
```

- [ ] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
