### PR TITLE
Experiment/dcp save ordering

### DIFF
--- a/s3torchconnector/src/s3torchconnector/dcp/s3_file_system.py
+++ b/s3torchconnector/src/s3torchconnector/dcp/s3_file_system.py
@@ -7,7 +7,7 @@ import os
 import urllib.parse
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Union, Optional
+from typing import Generator, Union, Optional, Callable, Any
 from typing import List
 
 from s3torchconnectorclient._mountpoint_s3_client import S3Exception
@@ -252,7 +252,7 @@ class S3FileSystem(FileSystemBase):
         return "/".join(parts)
 
 
-from torch.distributed.checkpoint.planner import SavePlan
+from torch.distributed.checkpoint.planner import SavePlan, LoadPlan
 import dataclasses
 from dataclasses import dataclass
 
@@ -264,6 +264,21 @@ class StorageMetadata:
     prefix: str
 
 
+from torch.distributed.checkpoint.filesystem import (
+    _split_by_size_and_type as original_split,
+)
+
+
+def _ordered_split_by_size_and_type(
+    bins: int, items: List[Any], sort_key: Optional[Callable] = None
+) -> List[List[Any]]:
+    buckets = original_split(bins, items)
+    if sort_key:
+        for bucket in buckets:
+            bucket.sort(key=sort_key)
+    return buckets
+
+
 class S3StorageWriter(FileSystemWriter):
     def __init__(
         self,
@@ -271,6 +286,7 @@ class S3StorageWriter(FileSystemWriter):
         path: str,
         s3client_config: Optional[S3ClientConfig] = None,
         prefix_strategy: Optional[S3PrefixStrategyBase] = None,
+        sort_key: Optional[Callable] = None,
         **kwargs,
     ) -> None:
         """
@@ -292,6 +308,16 @@ class S3StorageWriter(FileSystemWriter):
         self.fs = S3FileSystem(region, s3client_config=s3client_config)  # type: ignore
         self.path = self.fs.init_path(path)
         self.prefix_strategy = prefix_strategy or DefaultPrefixStrategy()
+        self.sort_key = sort_key
+
+        if self.sort_key:
+            # Replace the original split function with ours that will sort tensors/weights
+            import torch.distributed.checkpoint.filesystem as fs_module
+            from functools import partial
+
+            fs_module._split_by_size_and_type = partial(
+                _ordered_split_by_size_and_type, sort_key=sort_key
+            )
 
     def prepare_global_plan(self, plans: List[SavePlan]) -> List[SavePlan]:
         """
@@ -341,6 +367,11 @@ class S3StorageReader(FileSystemReader):
     @classmethod
     def validate_checkpoint_id(cls, checkpoint_id: Union[str, os.PathLike]) -> bool:
         return S3FileSystem.validate_checkpoint_id(checkpoint_id)
+
+    def prepare_local_plan(self, plan: LoadPlan) -> LoadPlan:
+        # Sort items in plan based on their offset in checkpoints shards
+        plan.items.sort(key=lambda item: self.storage_data[item.storage_index].offset)
+        return plan
 
 
 def _path_or_str_to_str(path: Union[str, os.PathLike]) -> str:


### PR DESCRIPTION
## Description
Improved Performance for Partial Checkpoint Loading

### Background
By default, PyTorch sorts checkpoint data based on size, which distributes tensors/weights randomly across checkpoint shards. While this approach works well with local storage, it can impact performance when working with cloud storage. Currently, PyTorch's checkpoint loading process doesn't follow the same order used during saving, resulting in non-sequential file access patterns.

### Changes

#### 1. Sequential Read Optimization
- Modified the ordering of items in LocalPlan based on their actual offset in checkpoint shards
- Ensures sequential reading of data, improving I/O efficiency

#### 2. Custom Sorting for Partial Loading
- Added ability to provide a custom sorting key function during checkpoint saving
- Allows users to group specific data at the beginning of checkpoints
- Optimizes partial loading scenarios by reducing the amount of data that needs to be read

### Usage Example
If you need to load only model layers that start with "model.model.layers.1", you can group these tensors at the beginning of checkpoint shards:

```python
def sort_key_func(item):
    return not item.index.fqn.startswith("model.model.layers.1"), item.index.fqn

def save_checkpoint(state_dict, region, uri):
    writer = S3StorageWriter(region, uri, sort_key=sort_key_func)
    dcp.save(state_dict, storage_writer=storage_writer)

``` 

#### Results

The resulting checkpoint shard layout will prioritize tensors starting with "model.model.layers.1":
```
File name: __0_0.distcp
        key: model.model.layers.10.self_attn.o_proj.weight     ,        offset: 0
        key: model.model.layers.11.mlp.down_proj.weight        ,        offset: 67110441
        key: model.model.layers.11.self_attn.k_proj.weight     ,        offset: 247467090
        key: model.model.layers.13.mlp.gate_proj.weight        ,        offset: 314577531
        key: model.model.layers.15.input_layernorm.weight      ,        offset: 494934180
        key: model.model.layers.15.post_attention_layernorm.weight,     offset: 494952141
        ...
        key: model.lm_head.weight                              ,        offset: 1124125164
        key: model.model.embed_tokens.weight                   ,        offset: 1950404629
        key: model.model.layers.21.mlp.gate_proj.weight        ,        offset: 2776684094
        ....
```


- [ ] I have updated the CHANGELOG or README if appropriate

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
