### PR TITLE
Feature/multi gpu dcp benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fix SequentialS3Reader to stay at EOF when seeking beyond object size (#362)
 
 ### Other changes
+* Extended benchmarks to support multi-GPU Dataloading
 * Add seekable() method in S3Reader to eliminate tensor copies during DCP loading (#359)
 * Add load ordering optimization to S3StorageReader for sequential access patterns (#372)
 * Add os, arch, and PyTorch version to user agent string (#397)
@@ -31,9 +32,6 @@
 
 ### Breaking changes
 * No breaking changes, but DCPOptimizedS3Reader as the new default reader for `S3StorageReader` might lead to behavioral changes. See [DCPOptimizedS3Reader Errors](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/docs/TROUBLESHOOTING.md#dcpoptimizeds3reader-errors) for more details.
-
-### Other changes
-* Extended benchmarks to support multi-GPU Dataloading
 
 ## v1.4.3 (July 25, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 ### Breaking changes
 * No breaking changes, but DCPOptimizedS3Reader as the new default reader for `S3StorageReader` might lead to behavioral changes. See [DCPOptimizedS3Reader Errors](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/docs/TROUBLESHOOTING.md#dcpoptimizeds3reader-errors) for more details.
 
+### Other changes
+* Extended benchmarks to support multi-GPU Dataloading
+
 ## v1.4.3 (July 25, 2025)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Other changes
 * Bump PyO3 from 0.27.2 to 0.29.0
+* Extended benchmarks to support multi-GPU Dataloading (#356)
 
 ### Breaking changes
 
@@ -28,7 +29,6 @@
 * Add benchmark to run DCP Loading Workloads (#357)
 * Add thread_count parameter to S3StorageWriter (#370)
 * Add macOS x86_64 and Python 3.8 deprecation warnings (#400)
-* Extended benchmarks to support multi-GPU Dataloading (#356)
 
 ### Breaking changes
 * No breaking changes, but DCPOptimizedS3Reader as the new default reader for `S3StorageReader` might lead to behavioral changes. See [DCPOptimizedS3Reader Errors](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/docs/TROUBLESHOOTING.md#dcpoptimizeds3reader-errors) for more details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,13 @@
 * Fix SequentialS3Reader to stay at EOF when seeking beyond object size (#362)
 
 ### Other changes
-* Extended benchmarks to support multi-GPU Dataloading
 * Add seekable() method in S3Reader to eliminate tensor copies during DCP loading (#359)
 * Add load ordering optimization to S3StorageReader for sequential access patterns (#372)
 * Add os, arch, and PyTorch version to user agent string (#397)
 * Add benchmark to run DCP Loading Workloads (#357)
 * Add thread_count parameter to S3StorageWriter (#370)
 * Add macOS x86_64 and Python 3.8 deprecation warnings (#400)
+* Extended benchmarks to support multi-GPU Dataloading (#356)
 
 ### Breaking changes
 * No breaking changes, but DCPOptimizedS3Reader as the new default reader for `S3StorageReader` might lead to behavioral changes. See [DCPOptimizedS3Reader Errors](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/docs/TROUBLESHOOTING.md#dcpoptimizeds3reader-errors) for more details.

--- a/s3torchbenchmarking/README.md
+++ b/s3torchbenchmarking/README.md
@@ -93,6 +93,27 @@ Here are some sample dataset configurations that we ran our benchmarks against:
 s3torch-datagen -n 100k --shard-size 128MiB --s3-bucket my-bucket --region us-east-1
 ```
 
+## Multi-GPU dataset benchmarks
+
+Setting `num_gpus > 1` in `conf/dataset.yaml` enables multi-GPU benchmarking via DDP (DistributedDataParallel).
+This measures data loading throughput under realistic multi-GPU training conditions where multiple processes
+pull data from S3 simultaneously.
+
+**Behavior when `num_gpus > 1`:**
+
+- One process is spawned per GPU via `mp.spawn`
+- Each process runs the full training loop independently on its assigned GPU
+- A `capped_loader` ensures all ranks process the same number of batches to prevent DDP hangs:
+  - Map-style datasets (S3MapDataset): uses `DistributedSampler` to shard indices across ranks; `capped_loader` caps iteration to `min(len)` across all ranks
+  - Iterable datasets (S3IterableDataset): enables `enable_sharding` to split objects across ranks; `capped_loader` synchronizes per-batch and stops all ranks when any rank exhausts its data
+- `drop_last` is forced to `true` (DDP requires equal batch sizes across ranks)
+- Some samples may be skipped due to capping/dropping; check `volume` in metrics for actual count
+
+**Constraints:**
+
+- `model=entitlement` always runs single-GPU (I/O-only benchmark, no gradient sync needed)
+- Only `s3iterabledataset` and `s3mapdataset` support multi-GPU sharding; other backends run unsharded
+
 ## Running the benchmarks
 
 You can run the different benchmarks by editing their corresponding config files, then running one of those shell

--- a/s3torchbenchmarking/README.md
+++ b/s3torchbenchmarking/README.md
@@ -202,8 +202,8 @@ pull data from S3 simultaneously.
 - A `capped_loader` ensures all ranks process the same number of batches to prevent DDP hangs:
   - Map-style datasets (S3MapDataset): uses `DistributedSampler` to shard indices across ranks; `capped_loader` caps iteration to `min(len)` across all ranks
   - Iterable datasets (S3IterableDataset): enables `enable_sharding` to split objects across ranks; `capped_loader` synchronizes per-batch and stops all ranks when any rank exhausts its data
-- `drop_last` is forced to `true` (DDP requires equal batch sizes across ranks)
-- Some samples may be skipped due to capping/dropping; check `volume` in metrics for actual count
+- `drop_last` defaults to `true` under multi-GPU so a short final batch doesn't skew per-rank step counts. Setting it to `false` is safe — `capped_loader` already keeps ranks in step, so it won't hang.
+- Some samples may be skipped due to capping/dropping; check `volume` in metrics for the actual count
 
 **Constraints:**
 

--- a/s3torchbenchmarking/README.md
+++ b/s3torchbenchmarking/README.md
@@ -93,27 +93,6 @@ Here are some sample dataset configurations that we ran our benchmarks against:
 s3torch-datagen -n 100k --shard-size 128MiB --s3-bucket my-bucket --region us-east-1
 ```
 
-## Multi-GPU dataset benchmarks
-
-Setting `num_gpus > 1` in `conf/dataset.yaml` enables multi-GPU benchmarking via DDP (DistributedDataParallel).
-This measures data loading throughput under realistic multi-GPU training conditions where multiple processes
-pull data from S3 simultaneously.
-
-**Behavior when `num_gpus > 1`:**
-
-- One process is spawned per GPU via `mp.spawn`
-- Each process runs the full training loop independently on its assigned GPU
-- A `capped_loader` ensures all ranks process the same number of batches to prevent DDP hangs:
-  - Map-style datasets (S3MapDataset): uses `DistributedSampler` to shard indices across ranks; `capped_loader` caps iteration to `min(len)` across all ranks
-  - Iterable datasets (S3IterableDataset): enables `enable_sharding` to split objects across ranks; `capped_loader` synchronizes per-batch and stops all ranks when any rank exhausts its data
-- `drop_last` is forced to `true` (DDP requires equal batch sizes across ranks)
-- Some samples may be skipped due to capping/dropping; check `volume` in metrics for actual count
-
-**Constraints:**
-
-- `model=entitlement` always runs single-GPU (I/O-only benchmark, no gradient sync needed)
-- Only `s3iterabledataset` and `s3mapdataset` support multi-GPU sharding; other backends run unsharded
-
 ## Running the benchmarks
 
 You can run the different benchmarks by editing their corresponding config files, then running one of those shell
@@ -209,3 +188,24 @@ will also be written to the specified table.
 [credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 
 [hydra-overrides]: https://hydra.cc/docs/advanced/override_grammar/basic/
+
+## Multi-GPU dataset benchmarks
+
+Setting `num_gpus > 1` in `conf/dataset.yaml` enables multi-GPU benchmarking via DDP ([DistributedDataParallel](https://docs.pytorch.org/tutorials/intermediate/ddp_tutorial.html)).
+This measures data loading throughput under realistic multi-GPU training conditions where multiple processes
+pull data from S3 simultaneously.
+
+**Behavior when `num_gpus > 1`:**
+
+- One process is spawned per GPU via `mp.spawn`
+- Each process runs the full training loop independently on its assigned GPU
+- A `capped_loader` ensures all ranks process the same number of batches to prevent DDP hangs:
+  - Map-style datasets (S3MapDataset): uses `DistributedSampler` to shard indices across ranks; `capped_loader` caps iteration to `min(len)` across all ranks
+  - Iterable datasets (S3IterableDataset): enables `enable_sharding` to split objects across ranks; `capped_loader` synchronizes per-batch and stops all ranks when any rank exhausts its data
+- `drop_last` is forced to `true` (DDP requires equal batch sizes across ranks)
+- Some samples may be skipped due to capping/dropping; check `volume` in metrics for actual count
+
+**Constraints:**
+
+- `model=entitlement` always runs single-GPU (I/O-only benchmark, no gradient sync needed)
+- Only `s3iterabledataset` and `s3mapdataset` support multi-GPU sharding; other backends run unsharded

--- a/s3torchbenchmarking/conf/dataset.yaml
+++ b/s3torchbenchmarking/conf/dataset.yaml
@@ -40,3 +40,4 @@ hydra:
       dataloader.s3reader.type: sequential
       # buffer_size (bytes): only used with range_based s3reader
       dataloader.s3reader.buffer_size: 8*1024*1024
+      +num_gpus: 1

--- a/s3torchbenchmarking/conf/dataset.yaml
+++ b/s3torchbenchmarking/conf/dataset.yaml
@@ -40,17 +40,12 @@ hydra:
       dataloader.s3reader.type: sequential
       # buffer_size (bytes): only used with range_based s3reader
       dataloader.s3reader.buffer_size: 8*1024*1024
-      # Number of GPUs to use for training.
-      # When num_gpus > 1:
-      #   - Uses DDP (DistributedDataParallel) via mp.spawn
-      #   - S3IterableDataset enables sharding across ranks
-      #   - S3MapDataset uses DistributedSampler
-      #   - capped_loader ensures all ranks process the same number of batches
-      # When num_gpus = 1 (or model=entitlement):
-      #   - Single process, no DDP overhead
+      # Number of GPUs to use (default: 1 = single process, no DDP).
+      # Setting num_gpus > 1 enables DDP via mp.spawn. See README for details.
+      # Note: model=entitlement always forces num_gpus=1 (I/O-only, no training).
       +num_gpus: 1
-      # Whether to drop the last incomplete batch from each worker.
-      # "auto" (default): True for multi-GPU (required for DDP synchronization),
-      #                    False for single-GPU (all data is processed).
-      # Can be overridden to "true" or "false" explicitly.
+      # Whether to drop the last incomplete batch.
+      # "auto" (default): True when num_gpus > 1, False otherwise.
+      # Multi-GPU requires drop_last=true for DDP synchronization; setting it to
+      # false with num_gpus > 1 will cause training to hang.
       +drop_last: auto

--- a/s3torchbenchmarking/conf/dataset.yaml
+++ b/s3torchbenchmarking/conf/dataset.yaml
@@ -40,4 +40,17 @@ hydra:
       dataloader.s3reader.type: sequential
       # buffer_size (bytes): only used with range_based s3reader
       dataloader.s3reader.buffer_size: 8*1024*1024
+      # Number of GPUs to use for training.
+      # When num_gpus > 1:
+      #   - Uses DDP (DistributedDataParallel) via mp.spawn
+      #   - S3IterableDataset enables sharding across ranks
+      #   - S3MapDataset uses DistributedSampler
+      #   - capped_loader ensures all ranks process the same number of batches
+      # When num_gpus = 1 (or model=entitlement):
+      #   - Single process, no DDP overhead
       +num_gpus: 1
+      # Whether to drop the last incomplete batch from each worker.
+      # "auto" (default): True for multi-GPU (required for DDP synchronization),
+      #                    False for single-GPU (all data is processed).
+      # Can be overridden to "true" or "false" explicitly.
+      +drop_last: auto

--- a/s3torchbenchmarking/conf/dataset.yaml
+++ b/s3torchbenchmarking/conf/dataset.yaml
@@ -44,11 +44,7 @@ hydra:
       # Setting num_gpus > 1 enables DDP via mp.spawn. See README for details.
       # Note: model=entitlement always forces num_gpus=1 (I/O-only, no training).
       +num_gpus: 1
-      # Whether each rank drops its final batch when it has fewer than batch_size samples.
-      # "auto" (default): True when num_gpus > 1, False otherwise.
-      # This won't hang if set to false under multi-GPU: capped_loader already
-      # equalises the step count across ranks (map: min(len); iterable: stop when
-      # any rank exhausts), and that step-count sync is what prevents DDP hangs.
-      # drop_last defaults to true for multi-GPU only to keep per-rank step counts
-      # even so throughput/samples-per-epoch stay comparable across ranks.
+      # Whether each rank drops its final short batch (fewer than batch_size samples).
+      # "auto" (default): true under multi-GPU, false otherwise. See README for when
+      # to override and why false is still safe under multi-GPU.
       +drop_last: auto

--- a/s3torchbenchmarking/conf/dataset.yaml
+++ b/s3torchbenchmarking/conf/dataset.yaml
@@ -44,8 +44,11 @@ hydra:
       # Setting num_gpus > 1 enables DDP via mp.spawn. See README for details.
       # Note: model=entitlement always forces num_gpus=1 (I/O-only, no training).
       +num_gpus: 1
-      # Whether to drop the last incomplete batch.
+      # Whether each rank drops its final batch when it has fewer than batch_size samples.
       # "auto" (default): True when num_gpus > 1, False otherwise.
-      # Multi-GPU requires drop_last=true for DDP synchronization; setting it to
-      # false with num_gpus > 1 will cause training to hang.
+      # This won't hang if set to false under multi-GPU: capped_loader already
+      # equalises the step count across ranks (map: min(len); iterable: stop when
+      # any rank exhausts), and that step-count sync is what prevents DDP hangs.
+      # drop_last defaults to true for multi-GPU only to keep per-rank step counts
+      # even so throughput/samples-per-epoch stay comparable across ranks.
       +drop_last: auto

--- a/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
@@ -88,7 +88,7 @@ class ResourceMonitor:
                     gpu_mem_info = nvmlDeviceGetMemoryInfo(
                         nvmlDeviceGetHandleByIndex(gpu_id)
                     )
-                    self._utilization[f"gpu_{gpu_id}_util"].add(gpu_info.gpu)
+                    self._utilization[f"gpu_{gpu_id}_mem"].add(gpu_info.gpu)
                     self._utilization[f"gpu_{gpu_id}_util"].add(
                         gpu_mem_info.used / gpu_mem_info.total * 100
                     )

--- a/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
@@ -82,12 +82,9 @@ class ResourceMonitor:
 
             if monitor_gpu:
                 for gpu_id in range(self.num_of_gpus):
-                    gpu_info = nvmlDeviceGetUtilizationRates(
-                        nvmlDeviceGetHandleByIndex(gpu_id)
-                    )
-                    gpu_mem_info = nvmlDeviceGetMemoryInfo(
-                        nvmlDeviceGetHandleByIndex(gpu_id)
-                    )
+                    nvml_device_handle = nvmlDeviceGetHandleByIndex(gpu_id)
+                    gpu_info = nvmlDeviceGetUtilizationRates(nvml_device_handle)
+                    gpu_mem_info = nvmlDeviceGetMemoryInfo(nvml_device_handle)
                     self._utilization[f"gpu_{gpu_id}_mem"].add(gpu_info.gpu)
                     self._utilization[f"gpu_{gpu_id}_util"].add(
                         gpu_mem_info.used / gpu_mem_info.total * 100

--- a/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
@@ -66,7 +66,7 @@ class ResourceMonitor:
     """
 
     def __init__(
-        self, sleep_time_s: float = 0.05, gpu_device: int = 0, chunk_size: int = 25_000
+        self, sleep_time_s: float = 0.05, chunk_size: int = 25_000
     ):
         self.monitor_thread = None
         self._utilization: Dict[str, Distribution] = defaultdict(
@@ -74,7 +74,7 @@ class ResourceMonitor:
         )
         self.stop_event = threading.Event()
         self.sleep_time_s = sleep_time_s
-        self.gpu_device = gpu_device
+        self.num_of_gpus = torch.cuda.device_count() if monitor_gpu else 0
         self.chunk_size = chunk_size
 
     def _monitor(self):
@@ -83,16 +83,17 @@ class ResourceMonitor:
             self._utilization["cpu_mem"].add(psutil.virtual_memory().percent)
 
             if monitor_gpu:
-                gpu_info = nvmlDeviceGetUtilizationRates(
-                    nvmlDeviceGetHandleByIndex(self.gpu_device)
-                )
-                gpu_mem_info = nvmlDeviceGetMemoryInfo(
-                    nvmlDeviceGetHandleByIndex(self.gpu_device)
-                )
-                self._utilization["gpu_util"].add(gpu_info.gpu)
-                self._utilization["gpu_mem"].add(
-                    gpu_mem_info.used / gpu_mem_info.total * 100
-                )
+                for gpu_id in range(self.num_of_gpus):
+                    gpu_info = nvmlDeviceGetUtilizationRates(
+                        nvmlDeviceGetHandleByIndex(gpu_id)
+                    )
+                    gpu_mem_info = nvmlDeviceGetMemoryInfo(
+                        nvmlDeviceGetHandleByIndex(gpu_id)
+                    )
+                    self._utilization[f"gpu_{gpu_id}_util"].add(gpu_info.gpu)
+                    self._utilization[f"gpu_{gpu_id}_util"].add(
+                        gpu_mem_info.used / gpu_mem_info.total * 100
+                    )
             time.sleep(self.sleep_time_s)
 
     @property

--- a/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
@@ -65,9 +65,7 @@ class ResourceMonitor:
     Set sleep_time_s carefully to avoid perf degradations.
     """
 
-    def __init__(
-        self, sleep_time_s: float = 0.05, chunk_size: int = 25_000
-    ):
+    def __init__(self, sleep_time_s: float = 0.05, chunk_size: int = 25_000):
         self.monitor_thread = None
         self._utilization: Dict[str, Distribution] = defaultdict(
             lambda: Distribution(chunk_size)

--- a/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/benchmark_utils.py
@@ -85,8 +85,8 @@ class ResourceMonitor:
                     nvml_device_handle = nvmlDeviceGetHandleByIndex(gpu_id)
                     gpu_info = nvmlDeviceGetUtilizationRates(nvml_device_handle)
                     gpu_mem_info = nvmlDeviceGetMemoryInfo(nvml_device_handle)
-                    self._utilization[f"gpu_{gpu_id}_mem"].add(gpu_info.gpu)
-                    self._utilization[f"gpu_{gpu_id}_util"].add(
+                    self._utilization[f"gpu_{gpu_id}_util"].add(gpu_info.gpu)
+                    self._utilization[f"gpu_{gpu_id}_mem"].add(
                         gpu_mem_info.used / gpu_mem_info.total * 100
                     )
             time.sleep(self.sleep_time_s)

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -389,7 +389,9 @@ def make_dataloader(dataset: Dataset, num_workers: int, batch_size: int, sampler
         pin_memory=False,
         persistent_workers=True,
         prefetch_factor=2 if num_workers > 0 else None,
-        multiprocessing_context="fork",
+        # We use fork here when using multiple GPUs otherwise this will cause a hang
+        # otherwise we use spawn
+        multiprocessing_context="fork" if torch.cuda.is_available() and torch.cuda.device_count() > 0 else "spawn",
     )
 
 

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -294,7 +294,7 @@ def create_s3_iterable_dataset(
 ):
     reader_constructor = make_s3_reader_constructor(s3reader_config)
     enable_sharding = world_size > 1
-    logging.info(
+    logger.info(
         f"Enabled sharding:  {enable_sharding}, because world_size is {world_size}"
     )
     dataset = S3IterableDataset.from_prefix(

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -32,12 +32,11 @@ from s3torchconnector._s3dataset_common import parse_s3_uri  # type: ignore
 
 logger = logging.getLogger(__name__)
 import sys
+
 logging.basicConfig(
-  level=logging.INFO,
-  format="%(asctime)s [%(levelname)s] %(message)s",
-  handlers=[
-    logging.StreamHandler(sys.stdout)
-  ]
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 
@@ -118,7 +117,9 @@ def run_ddp_process(rank, world_size, config, results_file):
                 "training_duration_s": avg_training_duration,
                 "volume_mibs": total_volume,
                 "per_rank_metrics": all_metrics,
-                "longest_training_time": max(m["training_duration_s"] for m in all_metrics)
+                "longest_training_time": max(
+                    m["training_duration_s"] for m in all_metrics
+                ),
             }
 
             with open(results_file, "w") as f:

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -366,7 +366,5 @@ def validate_dataset_coverage(dataset, sampler, world_size, rank):
 
 if __name__ == "__main__":    
     os.environ['OMP_NUM_THREADS'] = '1'
-    os.environ['MKL_NUM_THREADS'] = '1'
-    os.environ['NCCL_P2P_DISABLE'] = '1'
-        
+    os.environ['MKL_NUM_THREADS'] = '1'        
     run_experiment()

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -31,13 +31,6 @@ from s3torchconnector.s3reader import S3ReaderConstructor, S3ReaderConstructorPr
 from s3torchconnector._s3dataset_common import parse_s3_uri  # type: ignore
 
 logger = logging.getLogger(__name__)
-import sys
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)],
-)
 
 
 def init_distributed(rank=0, world_size=1):

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -31,13 +31,7 @@ from s3torchconnector.s3reader import S3ReaderConstructor, S3ReaderConstructorPr
 from s3torchconnector._s3dataset_common import parse_s3_uri  # type: ignore
 
 logger = logging.getLogger(__name__)
-import sys
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)],
-)
 
 
 def init_distributed(rank=0, world_size=1):

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -22,7 +22,9 @@ from s3torchbenchmarking.models import (
 from s3torchconnector import S3MapDataset, S3Reader, S3IterableDataset
 from s3torchconnector.s3reader import S3ReaderConstructor, S3ReaderConstructorProtocol
 from s3torchconnector._s3dataset_common import parse_s3_uri  # type: ignore
-
+import torch
+import logging
+logger = logging.getLogger(__name__)
 
 # TODO: add Structured Config (https://hydra.cc/docs/tutorials/structured_config/intro/)
 @hydra.main(version_base=None)
@@ -32,7 +34,12 @@ def run_experiment(config: DictConfig) -> dict:
     fully_qualified_uri = (
         "s3://" + config.s3.bucket.strip("/") + "/" + config.dataset.strip("/")
     )
+    num_of_gpus = torch.cuda.device_count()
+    logging.info(f"CUDA available: {torch.cuda.is_available()}")
+    logging.info(f"CUDA version: {torch.version.cuda}")
+    logging.info(f"GPU count: {torch.cuda.device_count()}")
 
+    logging.info(f"Using {num_of_gpus} GPUs")
     dataset = make_dataset(
         dataloader_config=config.dataloader,
         sharding=config.sharding,

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -33,7 +33,6 @@ from s3torchconnector._s3dataset_common import parse_s3_uri  # type: ignore
 logger = logging.getLogger(__name__)
 
 
-
 def init_distributed(rank=0, world_size=1):
     """Initialize DDP Process group"""
     os.environ["MASTER_ADDR"] = "localhost"
@@ -385,7 +384,11 @@ def make_dataloader(dataset: Dataset, num_workers: int, batch_size: int, sampler
         prefetch_factor=2 if num_workers > 0 else None,
         # We use fork here when using multiple GPUs otherwise this will cause a hang
         # otherwise we use spawn
-        multiprocessing_context="fork" if torch.cuda.is_available() and torch.cuda.device_count() > 0 else "spawn",
+        multiprocessing_context=(
+            "fork"
+            if torch.cuda.is_available() and torch.cuda.device_count() > 0
+            else "spawn"
+        ),
     )
 
 

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -148,13 +148,12 @@ def run_benchmark_experiment(config: DictConfig):
         region=config.s3.region,
         load_sample=model.load_sample,
     )
-    drop_last_cfg = config.get("drop_last", "auto")
     dataloader = make_dataloader(
         dataset=dataset,
         sampler=sampler,
         num_workers=config.dataloader.num_workers,
         batch_size=config.dataloader.batch_size,
-        drop_last=drop_last_cfg,
+        drop_last=config.get("drop_last", "auto"),
     )
     if dist.is_available() and dist.is_initialized():
         torch.cuda.set_device(rank)

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -1,7 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 import atexit
-import datetime
 import json
 import logging
 import os
@@ -42,7 +41,6 @@ def init_distributed(rank=0, world_size=1):
         backend="nccl",
         rank=rank,
         world_size=world_size,
-        timeout=datetime.timedelta(minutes=5),
     )
 
 
@@ -72,34 +70,28 @@ def run_experiment(config: DictConfig) -> dict:
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, range(num_gpus)))
         torch.cuda.empty_cache()
 
-    # In the case of multiple GPU training we run run_ddp_process using mp.spawn for each of the ranks, which calls run_benchmark_experiment separately
-    # If single-rank training then it defaults to run_benchmark_experiment
     if num_gpus > 1 and not dist.is_initialized():
-        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
-            results_file = f.name
-        try:
-            mp.spawn(
-                run_ddp_process,
-                args=(num_gpus, config, results_file),
-                nprocs=num_gpus,
-                join=True,
-            )
-            # Read results from file
-            if os.path.exists(results_file):
-                try:
-                    with open(results_file, "r") as f:
-                        return json.load(f)
-                except (json.JSONDecodeError, IOError):
-                    return {"metrics": "DDP training completed - results file corrupted"}
-            else:
-                return {"metrics": "DDP training completed - no results file"}
-
-        finally:
-            # Cleanup
-            if os.path.exists(results_file):
-                os.unlink(results_file)
+        return run_distributed_experiment(num_gpus, config)
     else:
         return run_benchmark_experiment(config)
+
+
+def run_distributed_experiment(num_gpus: int, config: DictConfig) -> dict:
+    """Run benchmark across multiple GPUs using DDP via mp.spawn."""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
+        results_file = f.name
+    try:
+        mp.spawn(
+            run_ddp_process,
+            args=(num_gpus, config, results_file),
+            nprocs=num_gpus,
+            join=True,
+        )
+        with open(results_file, "r") as f:
+            return json.load(f)
+    finally:
+        if os.path.exists(results_file):
+            os.unlink(results_file)
 
 
 # DDP Process function for running only in multi-GPU cases
@@ -116,19 +108,19 @@ def run_ddp_process(rank, world_size, config, results_file):
         # Only rank 0 aggregates and writes results
         if rank == 0 and result:
             # Aggregate metrics
-            total_volume = sum(m.get("volume_mibs", 0) for m in all_metrics)
+            total_samples = sum(m.get("total_samples", 0) for m in all_metrics)
             avg_training_duration = (
                 sum(m["training_duration_s"] for m in all_metrics) / world_size
             )
 
             aggregated_metrics = {
                 "throughput_mibs": (
-                    total_volume / avg_training_duration
+                    total_samples / avg_training_duration
                     if avg_training_duration > 0
                     else 0
                 ),
                 "training_duration_s": avg_training_duration,
-                "volume_mibs": total_volume,
+                "total_samples": total_samples,
                 "per_rank_metrics": all_metrics,
                 "longest_training_time": max(
                     m["training_duration_s"] for m in all_metrics
@@ -149,7 +141,6 @@ def run_benchmark_experiment(config: DictConfig):
     fully_qualified_uri = (
         "s3://" + config.s3.bucket.strip("/") + "/" + config.dataset.strip("/") + "/"
     )
-    # We always return sample from make_dataset which could be None
     dataset, sampler = make_dataset(
         dataloader_config=config.dataloader,
         sharding=config.sharding,
@@ -184,7 +175,7 @@ def run_benchmark_experiment(config: DictConfig):
     metrics = {
         "throughput_mibs": result["volume"] / result["training_duration_s"],
         "training_duration_s": result["training_duration_s"],
-        "volume_mibs": result["volume"],
+        "total_samples": result["volume"],
         "samples_per_epoch": result["volume"] / config.epochs,
         "epoch_durations_s": result["epoch_durations_s"],
         "utilization": {k: v.summarize() for k, v in result["utilization"].items()},
@@ -315,7 +306,7 @@ def create_s3_iterable_dataset(
 ):
     reader_constructor = make_s3_reader_constructor(s3reader_config)
     enable_sharding = world_size > 1
-    logger.info(
+    logger.debug(
         f"Enabled sharding:  {enable_sharding}, because world_size is {world_size}"
     )
     dataset = S3IterableDataset.from_prefix(
@@ -355,7 +346,6 @@ def create_s3_map_dataset(
         transform=load_sample,
         reader_constructor=reader_constructor,
     )
-    dataset_size = len(dataset)
     if world_size > 1:
         sampler = DistributedSampler(
             dataset, num_replicas=world_size, rank=rank, drop_last=False, shuffle=False
@@ -408,10 +398,6 @@ def make_dataloader(
         drop_last=use_drop_last,
         num_workers=num_workers,
         collate_fn=default_collate,
-        pin_memory=torch.cuda.is_available(),
-        persistent_workers=num_workers > 0,
-        prefetch_factor=2 if num_workers > 0 else None,
-        multiprocessing_context="fork" if use_ddp else None,
     )
 
 

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -1,6 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 import atexit
+import datetime
 import json
 import logging
 import os
@@ -37,7 +38,12 @@ def init_distributed(rank=0, world_size=1):
     """Initialize DDP Process group"""
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = "12355"
-    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    dist.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+        timeout=datetime.timedelta(minutes=5),
+    )
 
 
 # TODO: add Structured Config (https://hydra.cc/docs/tutorials/structured_config/intro/)
@@ -47,7 +53,7 @@ def run_experiment(config: DictConfig) -> dict:
     num_gpus = (
         config.num_gpus if hasattr(config, "num_gpus") else torch.cuda.device_count()
     )
-    if num_gpus <= 0 or type(num_gpus) != int:
+    if not isinstance(num_gpus, int) or num_gpus <= 0:
         raise ValueError(
             "Invalid number of GPUs detected. Please specify a number of GPUs to use."
         )
@@ -80,8 +86,11 @@ def run_experiment(config: DictConfig) -> dict:
             )
             # Read results from file
             if os.path.exists(results_file):
-                with open(results_file, "r") as f:
-                    return json.load(f)
+                try:
+                    with open(results_file, "r") as f:
+                        return json.load(f)
+                except (json.JSONDecodeError, IOError):
+                    return {"metrics": "DDP training completed - results file corrupted"}
             else:
                 return {"metrics": "DDP training completed - no results file"}
 
@@ -148,17 +157,19 @@ def run_benchmark_experiment(config: DictConfig):
         region=config.s3.region,
         load_sample=model.load_sample,
     )
+    drop_last_cfg = config.get("drop_last", "auto")
     dataloader = make_dataloader(
         dataset=dataset,
         sampler=sampler,
         num_workers=config.dataloader.num_workers,
         batch_size=config.dataloader.batch_size,
+        drop_last=drop_last_cfg,
     )
     if dist.is_available() and dist.is_initialized():
         torch.cuda.set_device(rank)
         device_id = torch.cuda.current_device()
 
-        if model.model != None:
+        if model.model is not None:
             model.model = model.model.to(device_id)
             model.device = torch.device(f"cuda:{device_id}")
             model.model = torch.nn.parallel.DistributedDataParallel(
@@ -173,9 +184,8 @@ def run_benchmark_experiment(config: DictConfig):
     metrics = {
         "throughput_mibs": result["volume"] / result["training_duration_s"],
         "training_duration_s": result["training_duration_s"],
-        "volume_mibs": result[
-            "volume"
-        ],  # Includes number of samples for context on how many images were processed in total
+        "volume_mibs": result["volume"],
+        "samples_per_epoch": result["volume"] / config.epochs,
         "epoch_durations_s": result["epoch_durations_s"],
         "utilization": {k: v.summarize() for k, v in result["utilization"].items()},
     }
@@ -381,25 +391,27 @@ def create_fsspec_dataset(
     return dataset.map(load_sample)
 
 
-def make_dataloader(dataset: Dataset, num_workers: int, batch_size: int, sampler=None):
+def make_dataloader(
+    dataset: Dataset, num_workers: int, batch_size: int, sampler=None, drop_last="auto"
+):
+    use_ddp = dist.is_initialized() and dist.get_world_size() > 1
+    if drop_last == "auto":
+        use_drop_last = use_ddp
+    else:
+        use_drop_last = str(drop_last).lower() == "true"
+
     return DataLoader(
         dataset=dataset,
         batch_size=batch_size,
         sampler=sampler,
         shuffle=False,
-        drop_last=True,
+        drop_last=use_drop_last,
         num_workers=num_workers,
         collate_fn=default_collate,
-        pin_memory=False,
-        persistent_workers=True,
+        pin_memory=torch.cuda.is_available(),
+        persistent_workers=num_workers > 0,
         prefetch_factor=2 if num_workers > 0 else None,
-        # We use fork here when using multiple GPUs otherwise this will cause a hang
-        # otherwise we use spawn
-        multiprocessing_context=(
-            "fork"
-            if torch.cuda.is_available() and torch.cuda.device_count() > 0
-            else "spawn"
-        ),
+        multiprocessing_context="fork" if use_ddp else None,
     )
 
 

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -168,9 +168,10 @@ def run_benchmark_experiment(config: DictConfig):
             model.model = torch.nn.parallel.DistributedDataParallel(
                 model.model, device_ids=[rank], output_device=rank
             )
-            # Recreate optimizer AFTER DDP wrapping
-            model._optimizer = None  # Clear cached optimizer
-            model.optimizer = torch.optim.Adam(model.model.parameters(), lr=0.001)
+            # Rebuild the optimizer over the DDP-wrapped params. lr and optimizer
+            # choice stay defined solely in Model.optimizer.
+            model.__dict__.pop("optimizer", None)
+            _ = model.optimizer
 
     result: ExperimentResult = model.train(dataloader, config.epochs)
 

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -48,14 +48,14 @@ def init_distributed(rank=0, world_size=1):
 @hydra.main(version_base=None)
 def run_experiment(config: DictConfig) -> dict:
 
-    num_gpus = (
-        config.num_gpus if hasattr(config, "num_gpus") else torch.cuda.device_count()
-    )
+    num_gpus = config.num_gpus if hasattr(config, "num_gpus") else 1
     if not isinstance(num_gpus, int) or num_gpus <= 0:
         raise ValueError(
             "Invalid number of GPUs detected. Please specify a number of GPUs to use."
         )
-    elif num_gpus > torch.cuda.device_count():
+    # Only enforce the GPU-count ceiling for actual multi-GPU runs. num_gpus=1
+    # is single-process and runs on CPU-only hosts (device_count() == 0) too.
+    elif num_gpus > 1 and num_gpus > torch.cuda.device_count():
         raise ValueError(
             f"Number of GPUs specified ({num_gpus}) exceeds number of GPUs available ({torch.cuda.device_count()})"
         )
@@ -70,6 +70,9 @@ def run_experiment(config: DictConfig) -> dict:
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, range(num_gpus)))
         torch.cuda.empty_cache()
 
+    # Multi-GPU runs go through run_distributed_experiment, which spawns one
+    # process per GPU via mp.spawn and runs DDP. Single-GPU (or already inside a
+    # spawned process) runs the benchmark directly in this process.
     if num_gpus > 1 and not dist.is_initialized():
         return run_distributed_experiment(num_gpus, config)
     else:
@@ -384,7 +387,7 @@ def make_dataloader(
     dataset: Dataset, num_workers: int, batch_size: int, sampler=None, drop_last="auto"
 ):
     use_ddp = dist.is_initialized() and dist.get_world_size() > 1
-    if drop_last == "auto":
+    if str(drop_last).lower() == "auto":
         use_drop_last = use_ddp
     else:
         use_drop_last = str(drop_last).lower() == "true"

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -196,13 +196,13 @@ class ModelInterface(ABC):
             begin_training = perf_counter()
             for epoch in range(epochs):
                 begin_epoch = time.perf_counter()
-                logger.info("Epoch #%i/%i", epoch, epochs - 1)
+                logger.info(f"Epoch #{epoch}/{epochs - 1}", epoch, epochs - 1)
                 batch_count = 0
                 try:
                     for batch_idx, (data, target) in enumerate(
                         self.capped_loader(dataloader)
                     ):
-                        logger.debug("Batch #%i", batch_idx)
+                        logger.debug(f"Batch #{batch_idx}")
                         result = self.train_batch(batch_idx, data, target)
                         num_samples += len(data)
                         batch_count += 1
@@ -295,7 +295,6 @@ class ViT(ModelInterface):
 
     def load_sample(self, sample: Union[S3Reader, Tuple[str, IOBase]]):
         key, data = super().load_sample(sample)
-
         img = Image.open(data)
         target = self._get_random_label()
         if self.transform:

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -196,7 +196,7 @@ class ModelInterface(ABC):
             begin_training = perf_counter()
             for epoch in range(epochs):
                 begin_epoch = time.perf_counter()
-                if dist.get_rank() == 0:
+                if not dist.is_initialized() or dist.get_rank() == 0:
                     logger.info(f"Epoch #{epoch}/{epochs - 1}")
                 batch_count = 0
                 try:

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -156,7 +156,7 @@ class ModelInterface(ABC):
         it = iter(loader)
         for _ in range(min_steps):
             yield next(it)
-            
+
     def train(self, dataloader: DataLoader, epochs: int) -> ExperimentResult:
         """Train the model using given dataloader for number of epochs"""
 
@@ -171,13 +171,17 @@ class ModelInterface(ABC):
                 logger.info("Epoch #%i/%i", epoch, epochs - 1)
                 batch_count = 0
                 try:
-                    for batch_idx, (data, target) in enumerate(self.capped_loader(dataloader)):
+                    for batch_idx, (data, target) in enumerate(
+                        self.capped_loader(dataloader)
+                    ):
                         logger.debug("Batch #%i", batch_idx)
                         result = self.train_batch(batch_idx, data, target)
                         num_samples += len(data)
                         batch_count += 1
                         if batch_count % 1000 == 0:
-                            logger.info(f"Processed {batch_count} batches, {num_samples} samples")
+                            logger.info(
+                                f"Processed {batch_count} batches, {num_samples} samples"
+                            )
                         if result:
                             checkpoint_times.append(result)
                 except Exception as e:

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -196,7 +196,8 @@ class ModelInterface(ABC):
             begin_training = perf_counter()
             for epoch in range(epochs):
                 begin_epoch = time.perf_counter()
-                logger.info(f"Epoch #{epoch}/{epochs - 1}", epoch, epochs - 1)
+                if dist.get_rank() == 0:
+                    logger.info(f"Epoch #{epoch}/{epochs - 1}")
                 batch_count = 0
                 try:
                     for batch_idx, (data, target) in enumerate(

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -177,7 +177,6 @@ class ModelInterface(ABC):
             except:
                 batch = None
                 flag.zero_()
-            # We know there's multiple gpus in this case
             dist.all_reduce(flag, op=dist.ReduceOp.MIN)
             if int(flag.item()) == 1:
                 yield batch

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -149,9 +149,13 @@ class ModelInterface(ABC):
             yield from loader
             return
         world = dist.get_world_size()
+        rank = dist.get_rank()
+
+        logger.info(
+            f"Rank {rank}: capped_loader active (world_size={world})"
+        )
 
         try:
-            # For map style datasets we can use len as we know the size of the loader
             local_steps = len(loader)
         except TypeError:
             local_steps = None
@@ -160,29 +164,37 @@ class ModelInterface(ABC):
             counts = [None] * world
             dist.all_gather_object(counts, local_steps)
             min_steps = min(counts)
+            logger.info(
+                f"Rank {rank}: capped_loader using map-style cap: "
+                f"min_steps={min_steps} (local={local_steps}, all={counts})"
+            )
             yield from itertools.islice(loader, min_steps)
             return
 
-        # In the case of iterable datasets we can't use len() so need to to use iter
+        logger.info(
+            f"Rank {rank}: capped_loader using iterable-style per-batch synchronization"
+        )
         it = iter(loader)
-        # Use cuda with nccl if available for the purpose of using dist.all_reduce
+        batch_count = 0
         while True:
-            # Pull out one batch one at at time, if it works on all ranks then we yield else stop
             try:
                 batch = next(it)
                 pulled_batch = 1
-            except:
+            except StopIteration:
                 batch = None
                 pulled_batch = 0
 
             flags = [None] * world
-            # We use all_gather_objects as the objects are of small size and the serialization
-            # overhead is too small to use dist.all_reduce_objectss
             dist.all_gather_object(flags, pulled_batch)
 
             if all(flags):
                 yield batch
+                batch_count += 1
             else:
+                logger.info(
+                    f"Rank {rank}: capped_loader stopping after {batch_count} batches "
+                    f"(flags={flags})"
+                )
                 break
 
     def train(self, dataloader: DataLoader, epochs: int) -> ExperimentResult:
@@ -196,6 +208,8 @@ class ModelInterface(ABC):
             begin_training = perf_counter()
             for epoch in range(epochs):
                 begin_epoch = time.perf_counter()
+                if hasattr(dataloader.sampler, "set_epoch"):
+                    dataloader.sampler.set_epoch(epoch)
                 if not dist.is_initialized() or dist.get_rank() == 0:
                     logger.info(f"Epoch #{epoch}/{epochs - 1}")
                 batch_count = 0

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -151,9 +151,7 @@ class ModelInterface(ABC):
         world = dist.get_world_size()
         rank = dist.get_rank()
 
-        logger.debug(
-            f"Rank {rank}: capped_loader active (world_size={world})"
-        )
+        logger.debug(f"Rank {rank}: capped_loader active (world_size={world})")
 
         try:
             local_steps = len(loader)

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -151,7 +151,7 @@ class ModelInterface(ABC):
         world = dist.get_world_size()
         rank = dist.get_rank()
 
-        logger.info(
+        logger.debug(
             f"Rank {rank}: capped_loader active (world_size={world})"
         )
 
@@ -164,14 +164,14 @@ class ModelInterface(ABC):
             counts = [None] * world
             dist.all_gather_object(counts, local_steps)
             min_steps = min(counts)
-            logger.info(
+            logger.debug(
                 f"Rank {rank}: capped_loader using map-style cap: "
                 f"min_steps={min_steps} (local={local_steps}, all={counts})"
             )
             yield from itertools.islice(loader, min_steps)
             return
 
-        logger.info(
+        logger.debug(
             f"Rank {rank}: capped_loader using iterable-style per-batch synchronization"
         )
         it = iter(loader)
@@ -191,7 +191,7 @@ class ModelInterface(ABC):
                 yield batch
                 batch_count += 1
             else:
-                logger.info(
+                logger.debug(
                     f"Rank {rank}: capped_loader stopping after {batch_count} batches "
                     f"(flags={flags})"
                 )
@@ -209,28 +209,20 @@ class ModelInterface(ABC):
             for epoch in range(epochs):
                 begin_epoch = time.perf_counter()
                 if hasattr(dataloader.sampler, "set_epoch"):
+                    # DistributedSampler needs epoch to reseed its shuffle each epoch
                     dataloader.sampler.set_epoch(epoch)
                 if not dist.is_initialized() or dist.get_rank() == 0:
                     logger.info(f"Epoch #{epoch}/{epochs - 1}")
                 batch_count = 0
-                try:
-                    for batch_idx, (data, target) in enumerate(
-                        self.capped_loader(dataloader)
-                    ):
-                        logger.debug(f"Batch #{batch_idx}")
-                        result = self.train_batch(batch_idx, data, target)
-                        num_samples += len(data)
-                        batch_count += 1
-                        if batch_count % 1000 == 0:
-                            logger.info(
-                                f"Processed {batch_count} batches, {num_samples} samples"
-                            )
-                        if result:
-                            checkpoint_times.append(result)
-                except Exception as e:
-                    logger.error(f"Error in training loop at batch {batch_count}: {e}")
-                    raise
-                logger.info(f"Epoch {epoch} completed with {batch_count} batches")
+                for batch_idx, (data, target) in enumerate(
+                    self.capped_loader(dataloader)
+                ):
+                    logger.debug(f"Batch #{batch_idx}")
+                    result = self.train_batch(batch_idx, data, target)
+                    num_samples += len(data)
+                    batch_count += 1
+                    if result:
+                        checkpoint_times.append(result)
                 epoch_durations_s.append(time.perf_counter() - begin_epoch)
             training_duration_s = time.perf_counter() - begin_training
 
@@ -260,12 +252,8 @@ class Entitlement(ModelInterface):
 
     def load_sample(self, sample: Union[S3Reader, Tuple[str, IOBase]]):
         key, data = super().load_sample(sample)
-        try:
-            buffer = data.read()
-            return len(buffer), key
-        except Exception as e:
-            logger.warning(f"Failed to read sample {key}: {e}")
-            return 0, key
+        buffer = data.read()
+        return len(buffer), key
 
     def train_batch(self, batch_idx: int, data, target):
         pass

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -1,5 +1,6 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
+import itertools
 import logging
 import os
 import random
@@ -20,7 +21,6 @@ from omegaconf import DictConfig
 from torch.nn import Module
 from torch.utils.data.dataloader import DataLoader
 from torchvision.transforms import v2  # type: ignore
-import itertools
 from transformers import (  # type: ignore
     ViTForImageClassification,
     ViTModel,

--- a/s3torchbenchmarking/src/s3torchbenchmarking/models.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/models.py
@@ -206,9 +206,6 @@ class ModelInterface(ABC):
             begin_training = perf_counter()
             for epoch in range(epochs):
                 begin_epoch = time.perf_counter()
-                if hasattr(dataloader.sampler, "set_epoch"):
-                    # DistributedSampler needs epoch to reseed its shuffle each epoch
-                    dataloader.sampler.set_epoch(epoch)
                 if not dist.is_initialized() or dist.get_rank() == 0:
                     logger.info(f"Epoch #{epoch}/{epochs - 1}")
                 batch_count = 0

--- a/s3torchbenchmarking/utils/run_dataset_benchmarks.sh
+++ b/s3torchbenchmarking/utils/run_dataset_benchmarks.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 #
+# Run dataset benchmarks.#
 # Run dataset benchmarks.
 
-./utils/run_benchmarks.sh -s dataset -d ./nvme/ "$@"
+# Check if multiple GPUs are available
+GPU_COUNT=$(python -c "import torch; print(torch.cuda.device_count())")
+
+if [ "$GPU_COUNT" -gt 1 ]; then
+    echo "Multiple GPUs detected ($GPU_COUNT). Using torchrun for distributed training."
+    torchrun --nproc_per_node="$GPU_COUNT" --nnodes=1 --node_rank=0 \
+        ./src/s3torchbenchmarking/dataset/benchmark.py -cd conf -cn dataset +path=./nvme/ "$@"
+else
+    echo "Single or no GPU detected. Using regular execution."
+    ./utils/run_benchmarks.sh -s dataset -d ./nvme/ "$@"
+fi

--- a/s3torchbenchmarking/utils/run_dataset_benchmarks.sh
+++ b/s3torchbenchmarking/utils/run_dataset_benchmarks.sh
@@ -1,16 +1,5 @@
 #!/usr/bin/env bash
 #
-# Run dataset benchmarks.#
 # Run dataset benchmarks.
 
-# Check if multiple GPUs are available
-GPU_COUNT=$(python -c "import torch; print(torch.cuda.device_count())")
-
-if [ "$GPU_COUNT" -gt 1 ]; then
-    echo "Multiple GPUs detected ($GPU_COUNT). Using torchrun for distributed training."
-    torchrun --nproc_per_node="$GPU_COUNT" --nnodes=1 --node_rank=0 \
-        ./src/s3torchbenchmarking/dataset/benchmark.py -cd conf -cn dataset +path=./nvme/ "$@"
-else
-    echo "Single or no GPU detected. Using regular execution."
-    ./utils/run_benchmarks.sh -s dataset -d ./nvme/ "$@"
-fi
+./utils/run_benchmarks.sh -s dataset -d ./nvme/ "$@"


### PR DESCRIPTION
## Description
Extended S3 Data Loading Benchmarks to support multi-GPU distributed traininng

## Additional context
Our current benchmarks currently only support a single GPU training. If you used multiple GPUs this would result in all GPUs except for 1 to be under-utilized.

## Changes Made
• **Multi-GPU Support**: Added distributed data parallel (DDP) training using torch.multiprocessing.spawn
• **Dataset Sharding**: 

- S3IterableDataset: We use enable_sharding=True for automatic data distribution as well as a wrapper around dataloader when enumerating to make sure that that each shard has an equal batch size and so we can cap steps to a global minimum
-  S3MapDataset: Uses DistributedSampler for proper data partitioning

• **Resource Monitoring**: Extended to track all GPU utilization instead of single GPU
• Environment optimizations (OMP_NUM_THREADS=1, NCCL_P2P_DISABLE=1)
• Added Dataset validation make sure no duplicate processing



## Performance Results
**S3IterableDataset (100k images, 134MB shards):**
• **Multi-GPU (4 GPUs)**: 218s/epoch, 82.6% avg utilization across all GPUs
• **Single-GPU**: 750s/epoch, 86% utilization on GPU 0 only
• **Improvement**: 3.5x throughput increase

**S3MapDataset (ViT model):**
• **Multi-GPU (4 GPUs)**: 231s training, ~78% utilization across all GPUs, 105 MiB/s
• **Single-GPU**: 817s training, 81% utilization on GPU 0 only, 122 MiB/s  
• **Improvement**: 3.5x throughput increase


### Logic in Capped Loader
One issue of running multi-GPU training is that the data sharded between the GPUs must be the same size. Where this isn't possible, one solution to ensure even splitting is to trim the dataset so each GPUs contains the same number of batches. If this doesn't happen then there occurs a hang within the GPUs causing the training to fail.
With S3MapDataset, this is easy to do as we already know the size of the dataset and therefore we can use `len()` to discover the size of the dataset and therefore can know the maximum number of datapoints each GPU can train on whilst being evenly split.

With S3IterableDataset, this is harder to do as we don't know the size of the dataset and therefore can't know how to evenly split between the GPUs. My solution to this was to yield a batch from either GPU simultaneously whilst it is possible and if it isn't possible to yield another batch we stop our training at that moment.

We ensure quick inter-process communication using `dist.all_gather_objects` and therefore can early-stop when needed.

By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
