### PR TITLE
Add Load Benchmarking Support for DCP DDP and FSDP

### DIFF
--- a/s3torchbenchmarking/conf/dcp_ddp_load.yaml
+++ b/s3torchbenchmarking/conf/dcp_ddp_load.yaml
@@ -1,0 +1,31 @@
+defaults:
+  - hydra/callbacks/collate_results
+  - aws/dynamodb # save run results to DynamoDB -- comment me if not required
+  - _self_
+
+# S3 bucket to use to save checkpoints.
+# NOTE: a non-existing bucket will fail the benchmarks.
+s3:
+  region: # e.g., eu-west-1
+  uri: # e.g., s3://my-bucket/
+# Number of iterations for "saving" a model's checkpoint.
+# NOTE: this does not affect model training, as no actual training occurs in these benchmarks.
+epochs: 4
+
+hydra:
+  mode: MULTIRUN
+  sweep:
+    dir: multirun/${hydra.job.config_name}/${now:%Y-%m-%d_%H-%M-%S}
+  sweeper:
+    params:
+      # Short name of a pre-trained model (from Hugging Face), listed in `models.py`.
+      +model: vit-base, T0_3B
+      # Type of Torch distributed backend (valid options: "nccl", "gloo").
+      +backend: nccl
+      # Number of workers.
+      +world_size: 4
+      # Number of threads to use for saving the checkpoints.
+      +thread_count: 4
+      # Checkpoint storage location (valid options: "disk", "s3").
+      +checkpoint.storage: disk, s3
+      +checkpoint.suffix: 

--- a/s3torchbenchmarking/conf/dcp_fsdp_load.yaml
+++ b/s3torchbenchmarking/conf/dcp_fsdp_load.yaml
@@ -1,0 +1,39 @@
+defaults:
+  - hydra/callbacks/collate_results
+  - aws/dynamodb # save run results to DynamoDB -- comment me if not required
+  - _self_
+
+# S3 bucket to use to save checkpoints.
+# NOTE: a non-existing bucket will fail the benchmarks.
+s3:
+  region:  # e.g., eu-west-1
+  uri:   # e.g., s3://my-bucket/
+# Number of iterations for "saving" a model's checkpoint.
+# NOTE: this does not affect model training, as no actual training occurs in these benchmarks.
+epochs: 4
+
+hydra:
+  mode: MULTIRUN
+  sweep:
+    dir: multirun/${hydra.job.config_name}/${now:%Y-%m-%d_%H-%M-%S}
+  sweeper:
+    params:
+      # Short name of a pre-trained llama v2 model (valid options: "L7b", "L13b", "L30b", "L65b", "L70b").
+      +model: L7b, L13b, L30b
+      # Type of Torch distributed backend (valid options: "nccl", "gloo").
+      +backend: nccl
+      # Number of workers.
+      +world_size: 4
+      # Number of threads to use for saving the checkpoints.
+      +thread_count: 4
+      # Checkpoint storage location (valid options: "disk", "s3").
+      +checkpoint.storage: disk, s3
+      # Sharding strategy (valid options: "full", "hybrid").
+      +checkpoint.sharding_strategy: full
+      # Controls whether files are forcibly synced to disk (only relevant for "disk" storage).
+      # NOTE: We disabled this option to improve performance since FSDP checkpointing with
+      # forced syncing (maximum durability) was significantly slower than storage throughput.
+      # This setting has no effect when using "s3" storage.
+      +checkpoint.sync_files: false
+      +checkpoint.suffix: 
+

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp_common.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp_common.py
@@ -31,7 +31,6 @@ def setup(backend: str, world_size: int, rank: int) -> None:
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = "12355"
     os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
-
     dist.init_process_group(backend, world_size=world_size, rank=rank)
 
 
@@ -62,6 +61,7 @@ def get_reader(cfg: DictConfig, suffix: str) -> FileSystemReader:
         logger.info("Loading checkpoint from %s (S3)...", uri)
         return S3StorageReader(cfg.s3.region, uri)
     raise ValueError(f"Storage reader {cfg.checkpoint.storage} not supported")
+
 
 def benchmark_common_runner(
     cfg: DictConfig,

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp_ddp/README.md
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp_ddp/README.md
@@ -10,20 +10,40 @@ where memory requirements per GPU are manageable.
 
 ### Purpose
 
-These benchmarks focus on testing the "save" mechanism of PyTorch DCP (`torch.distributed.checkpoint.save`). The primary
-objectives are to evaluate the `s3torchconnector` library's performance against other libraries and local storage
-options, by measuring the following metrics:
+These benchmarks test both "save" and "load" mechanisms of PyTorch DCP (`torch.distributed.checkpoint.save` and `torch.distributed.checkpoint.load`). The primary objectives are to evaluate the `s3torchconnector` library's performance against other libraries and local storage options, by measuring the following metrics:
 
-- Checkpoint saving throughput (in MiB/s);
-- Checkpoint "corrected" save durations (in seconds), which exclude the influence of model load duration on the device.
+**Save Benchmarks:**
+- Checkpoint saving throughput (in MiB/s)
+- Checkpoint "corrected" save durations (in seconds), which exclude the influence of model load duration on the device
+
+**Load Benchmarks:**
+- Checkpoint loading throughput (in MiB/s)
+- Checkpoint "corrected" load durations (in seconds), which exclude the influence of process setup and model loading to device
 
 ### Configuration
 
-The benchmark runs can be customized through the [`dcp_ddp.yaml`](../../../conf/dcp_ddp.yaml) file.
+The benchmark runs can be customized through configuration files:
+
+- **Save benchmarks**: [`dcp_ddp.yaml`](../../../conf/dcp_ddp.yaml)
+- **Load benchmarks**: [`dcp_ddp_load.yaml`](../../../conf/dcp_ddp_load.yaml)
+
+The load configuration includes a `checkpoint.suffix` parameter that specifies which saved checkpoint to load.
 
 > [!IMPORTANT]
 > A `+path` option is passed to the running script ([`run_dcp_ddp_benchmarks.sh`](../../../utils/run_dcp_ddp_benchmarks.sh)),
 > and will be used only if `checkpoint.storage` key includes `disk`.
+
+### Usage
+
+**Save benchmarks (default):**
+```bash
+./utils/run_dcp_ddp_benchmarks.sh
+```
+
+**Load benchmarks:**
+```bash
+./utils/run_dcp_ddp_benchmarks.sh -l
+```
 
 ### References
 

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp_ddp/load_benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp_ddp/load_benchmark.py
@@ -1,0 +1,81 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+import logging
+from multiprocessing.queues import Queue
+from time import perf_counter
+from typing import Tuple
+
+import hydra
+import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+from omegaconf import DictConfig
+from torch.nn.parallel import DistributedDataParallel
+
+from s3torchbenchmarking.dcp_common import setup, get_reader, benchmark_common_runner
+from s3torchbenchmarking.models import get_benchmark_model, BenchmarkModel
+
+Timestamps = Tuple[float, float]
+logger = logging.getLogger(__name__)
+
+import sys
+logging.basicConfig(
+    stream=sys.stdout,
+    format="%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s",
+)
+logging.getLogger().setLevel(logging.DEBUG)
+# TODO: add Structured Config (https://hydra.cc/docs/tutorials/structured_config/intro/)
+@hydra.main(version_base=None)
+def run_benchmark(cfg: DictConfig) -> dict:
+    """DCP benchmarks entry point."""
+    benchmark_model = get_benchmark_model(cfg.model)
+
+    return benchmark_common_runner(cfg, run_ddp, (cfg, benchmark_model))
+
+
+def run_ddp(
+    rank: int,  # needs to be passed first (provided by `multiprocessing.spawn` automatically)
+    cfg: DictConfig,
+    proxy_model: BenchmarkModel,
+    suffix: str, 
+    load_timestamps: Queue,
+) -> None:
+    """Execute the actual code for checkpoint loading.
+
+    This function is meant to be executed in subprocesses."""
+    begin_process = perf_counter()
+    # Override random suffix with suffix from config
+    suffix = cfg.checkpoint.suffix
+    storage_reader = get_reader(cfg, suffix)
+    model_size = proxy_model.size
+    model = proxy_model.model
+
+    setup(cfg.backend, world_size=cfg.world_size, rank=rank)
+    if cfg.backend == "nccl":
+        device_id = rank % torch.cuda.device_count()
+        torch.cuda.set_device(device_id)
+        model.to(device_id)
+        model = DistributedDataParallel(model, device_ids=[device_id])
+    else:
+        device_id = rank % torch.cpu.device_count()
+        torch.cpu.set_device(device_id)
+        model.to(device=torch.device("cpu"))
+        model = DistributedDataParallel(model)
+
+    state_dict = model.state_dict()
+
+    begin_load = perf_counter()  # also "end_process"
+    dcp.load(state_dict, storage_reader=storage_reader)
+    end_load = perf_counter()
+
+    # Record the load times excluding the influence of the process setup and model loading to device.
+    load_timestamps.put(
+        (begin_process, end_load - (begin_load - begin_process), model_size)
+    )
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp_ddp/load_benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp_ddp/load_benchmark.py
@@ -20,11 +20,14 @@ Timestamps = Tuple[float, float]
 logger = logging.getLogger(__name__)
 
 import sys
+
 logging.basicConfig(
     stream=sys.stdout,
     format="%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s",
 )
 logging.getLogger().setLevel(logging.DEBUG)
+
+
 # TODO: add Structured Config (https://hydra.cc/docs/tutorials/structured_config/intro/)
 @hydra.main(version_base=None)
 def run_benchmark(cfg: DictConfig) -> dict:
@@ -38,7 +41,7 @@ def run_ddp(
     rank: int,  # needs to be passed first (provided by `multiprocessing.spawn` automatically)
     cfg: DictConfig,
     proxy_model: BenchmarkModel,
-    suffix: str, 
+    suffix: str,
     load_timestamps: Queue,
 ) -> None:
     """Execute the actual code for checkpoint loading.

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp_fsdp/README.md
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp_fsdp/README.md
@@ -10,20 +10,40 @@ for training large models that wouldn't fit in a single GPU's memory.
 
 ### Purpose
 
-These benchmarks focus on testing the "save" mechanism of PyTorch DCP (`torch.distributed.checkpoint.save`). The primary
-objectives are to evaluate the `s3torchconnector` library's performance against other libraries and local storage
-options, by measuring the following metrics:
+These benchmarks test both "save" and "load" mechanisms of PyTorch DCP (`torch.distributed.checkpoint.save` and `torch.distributed.checkpoint.load`). The primary objectives are to evaluate the `s3torchconnector` library's performance against other libraries and local storage options, by measuring the following metrics:
 
-- Checkpoint saving throughput (in MiB/s);
-- Checkpoint "corrected" save durations (in seconds), which exclude the influence of model load duration on the device.
+**Save Benchmarks:**
+- Checkpoint saving throughput (in MiB/s)
+- Checkpoint "corrected" save durations (in seconds), which exclude the influence of model load duration on the device
+
+**Load Benchmarks:**
+- Checkpoint loading throughput (in MiB/s)
+- Checkpoint "corrected" load durations (in seconds), which exclude the influence of process setup and model loading to device
 
 ### Configuration
 
-The benchmark runs can be customized through the [`dcp_fsdp.yaml`](../../../conf/dcp_fsdp.yaml) file.
+The benchmark runs can be customized through configuration files:
+
+- **Save benchmarks**: [`dcp_fsdp.yaml`](../../../conf/dcp_fsdp.yaml)
+- **Load benchmarks**: [`dcp_fsdp_load.yaml`](../../../conf/dcp_fsdp_load.yaml)
+
+The load configuration includes a `checkpoint.suffix` parameter that specifies which saved checkpoint to load.
 
 > [!IMPORTANT]
 > A `+path` option is passed to the running script ([`run_dcp_fsdp_benchmarks.sh`](../../../utils/run_dcp_fsdp_benchmarks.sh)),
 > and will be used only if `checkpoint.storage` key includes `disk`.
+
+### Usage
+
+**Save benchmarks (default):**
+```bash
+./utils/run_dcp_fsdp_benchmarks.sh
+```
+
+**Load benchmarks:**
+```bash
+./utils/run_dcp_fsdp_benchmarks.sh -l
+```
 
 ### References
 

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp_fsdp/load_benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp_fsdp/load_benchmark.py
@@ -20,21 +20,25 @@ from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from transformers.models.llama.modeling_llama import LlamaDecoderLayer
 
-from s3torchbenchmarking.dcp_common import setup, benchmark_common_runner,  get_reader
+from s3torchbenchmarking.dcp_common import setup, benchmark_common_runner, get_reader
 from s3torchbenchmarking.models import get_benchmark_model
 
 Timestamps = Tuple[float, float]
 logger = logging.getLogger(__name__)
 import sys
+
 logging.basicConfig(
     stream=sys.stdout,
     format="%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s",
 )
 logging.getLogger().setLevel(logging.DEBUG)
+
+
 @hydra.main(version_base=None)
 def run_benchmark(cfg: DictConfig) -> dict:
     """DCP load benchmarks entry point."""
     return benchmark_common_runner(cfg, run_fsdp_load, (cfg,))
+
 
 def run_fsdp_load(
     rank: int,
@@ -49,7 +53,7 @@ def run_fsdp_load(
 
     if rank == 0:
         logger.info("Creating Model")
-        
+
     # Instantiate model on CPU on rank=0 only to prevent CPU OOM
     # (e.g. 70B * 4 bytes * 8 processes > 2T RAM available on P5)
     if rank == 0:
@@ -62,10 +66,9 @@ def run_fsdp_load(
             # and `sync_module_states=True` in FSDP c-tor.
             model_proxy = get_benchmark_model(cfg.model)
             model = model_proxy.model
-    
-    
+
     model_size = model_proxy.size
-    
+
     transformer_layer = LlamaDecoderLayer
     gpt_auto_wrap_policy = functools.partial(
         transformer_auto_wrap_policy,
@@ -107,8 +110,7 @@ def run_fsdp_load(
         sync_module_states=True if cfg.backend == "nccl" else False,
         param_init_fn=param_init_fn if rank != 0 else None,
     )
-    
-    
+
     if rank == 0:
         logger.info("Wrapped model with FSDP")
 
@@ -117,22 +119,23 @@ def run_fsdp_load(
         state_dict = {
             "model": model.state_dict(),
         }
-    
+
     # Get reader with the provided suffix
     suffix = cfg.checkpoint.suffix
     storage_reader = get_reader(cfg, suffix)
-    
+
     # Align all workers to start loading at the same time
     dist.barrier()
     begin_load = perf_counter()
     dcp.load(state_dict, storage_reader=storage_reader)
     end_load = perf_counter()
-    
+
     if rank == 0:
         logger.info(f"The total size of model is {model_size}")
     # Record the save times excluding the influence of the process setup and model loading to device.
     load_timestamps.put((begin_load, end_load, model_size))
     dist.destroy_process_group()
+
 
 if __name__ == "__main__":
     run_benchmark()

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dcp_fsdp/load_benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dcp_fsdp/load_benchmark.py
@@ -1,0 +1,138 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+import logging
+import functools
+from multiprocessing.queues import Queue
+from time import perf_counter
+from typing import Tuple
+
+import hydra
+import torch.distributed.checkpoint as dcp
+from omegaconf import DictConfig
+import torch
+import torch.distributed as dist
+import os
+
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import ShardingStrategy
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
+from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+
+from s3torchbenchmarking.dcp_common import setup, benchmark_common_runner,  get_reader
+from s3torchbenchmarking.models import get_benchmark_model
+
+Timestamps = Tuple[float, float]
+logger = logging.getLogger(__name__)
+import sys
+logging.basicConfig(
+    stream=sys.stdout,
+    format="%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s",
+)
+logging.getLogger().setLevel(logging.DEBUG)
+@hydra.main(version_base=None)
+def run_benchmark(cfg: DictConfig) -> dict:
+    """DCP load benchmarks entry point."""
+    return benchmark_common_runner(cfg, run_fsdp_load, (cfg,))
+
+def run_fsdp_load(
+    rank: int,
+    cfg: DictConfig,
+    suffix: str,
+    load_timestamps: Queue,
+):
+    """Execute the actual code for checkpoint saving.
+
+    This function is meant to be executed in subprocesses."""
+    setup(cfg.backend, world_size=cfg.world_size, rank=rank)
+
+    if rank == 0:
+        logger.info("Creating Model")
+        
+    # Instantiate model on CPU on rank=0 only to prevent CPU OOM
+    # (e.g. 70B * 4 bytes * 8 processes > 2T RAM available on P5)
+    if rank == 0:
+        model_proxy = get_benchmark_model(cfg.model)
+        model = model_proxy.model
+    else:
+        with torch.device("meta"):
+            # Instantiating model on `meta` device doesn't consume CPU memory,
+            # but requires specifing `param_init_fn=...`
+            # and `sync_module_states=True` in FSDP c-tor.
+            model_proxy = get_benchmark_model(cfg.model)
+            model = model_proxy.model
+    
+    
+    model_size = model_proxy.size
+    
+    transformer_layer = LlamaDecoderLayer
+    gpt_auto_wrap_policy = functools.partial(
+        transformer_auto_wrap_policy,
+        transformer_layer_cls={
+            transformer_layer,
+        },
+    )
+
+    if cfg.backend == "nccl":
+        device_id = rank % torch.cuda.device_count()
+        torch.cuda.set_device(device_id)
+        param_init_fn = lambda module: module.to_empty(
+            device=torch.device("cuda"), recurse=False
+        )
+    else:
+        device_id = rank % torch.cpu.device_count()
+        torch.cpu.set_device(device_id)
+        param_init_fn = lambda module: module.to_empty(
+            device=torch.device("cpu"), recurse=False
+        )
+
+    if cfg.checkpoint.sharding_strategy == "full":
+        sharding_strategy = ShardingStrategy.FULL_SHARD
+    elif cfg.checkpoint.sharding_strategy == "hybrid":
+        sharding_strategy = ShardingStrategy.HYBRID_SHARD
+    else:
+        raise NotImplementedError("Available sharding strategies are full and hybrid")
+
+    model = FSDP(
+        model,
+        auto_wrap_policy=gpt_auto_wrap_policy,
+        device_id=(
+            torch.cuda.current_device()
+            if cfg.backend == "nccl"
+            else torch.cpu.current_device()
+        ),
+        use_orig_params=False,
+        sharding_strategy=sharding_strategy,
+        sync_module_states=True if cfg.backend == "nccl" else False,
+        param_init_fn=param_init_fn if rank != 0 else None,
+    )
+    
+    
+    if rank == 0:
+        logger.info("Wrapped model with FSDP")
+
+    # Prepare state dict for loading
+    with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
+        state_dict = {
+            "model": model.state_dict(),
+        }
+    
+    # Get reader with the provided suffix
+    suffix = cfg.checkpoint.suffix
+    storage_reader = get_reader(cfg, suffix)
+    
+    # Align all workers to start loading at the same time
+    dist.barrier()
+    begin_load = perf_counter()
+    dcp.load(state_dict, storage_reader=storage_reader)
+    end_load = perf_counter()
+    
+    if rank == 0:
+        logger.info(f"The total size of model is {model_size}")
+    # Record the save times excluding the influence of the process setup and model loading to device.
+    load_timestamps.put((begin_load, end_load, model_size))
+    dist.destroy_process_group()
+
+if __name__ == "__main__":
+    run_benchmark()


### PR DESCRIPTION
# Add Load Benchmarking Support for DCP DDP and FSDP

## Summary
This PR extends the distributed checkpointing (DCP) benchmarking suite to support both save and load operations for DDP and FSDP training scenarios. Previously, the benchmarks only supported checkpoint saving; now users can benchmark checkpoint loading performance as well.

## Key Changes

### 🚀 **New Features**
- **Load Benchmarking**: Added `load_benchmark.py` files for both DCP DDP and FSDP scenarios
- **Unified Script Interface**: Extended `run_benchmarks.sh` with `-l` flag to switch between save (default) and load operations
- **Configuration Support**: Created dedicated load configuration files (`dcp_ddp_load.yaml`, `dcp_fsdp_load.yaml`) with `checkpoint.suffix` parameter

### 📁 **Files Added/Modified**

**New Files:**
- `src/s3torchbenchmarking/dcp_ddp/load_benchmark.py` - DDP load benchmarking implementation
- `src/s3torchbenchmarking/dcp_fsdp/load_benchmark.py` - FSDP load benchmarking implementation
- `conf/dcp_ddp_load.yaml` - Load configuration for DDP benchmarks
- `conf/dcp_fsdp_load.yaml` - Load configuration for FSDP benchmarks

**Modified Files:**
- `utils/run_benchmarks.sh` - Added `-l` flag support and config file selection logic
- `src/s3torchbenchmarking/dcp_common.py` - Enhanced with `get_reader()` function for load operations
- `src/s3torchbenchmarking/dcp_ddp/README.md` - Updated documentation
- `src/s3torchbenchmarking/dcp_fsdp/README.md` - Updated documentation

### 🔧 **Technical Implementation**
- **Reader Support**: Added `get_reader()` function in `dcp_common.py` to instantiate S3 and filesystem readers
- **Config-Driven Suffix**: Load benchmarks get checkpoint suffix from config (`cfg.checkpoint.suffix`) instead of parameters
- **Backward Compatibility**: Default behavior unchanged - save operations work exactly as before

### 📊 **Usage**
```bash
# Save benchmarks (default behavior)
./utils/run_dcp_ddp_benchmarks.sh
./utils/run_dcp_fsdp_benchmarks.sh

# Load benchmarks (new functionality)
./utils/run_dcp_ddp_benchmarks.sh -l
./utils/run_dcp_fsdp_benchmarks.sh -l
