### PR TITLE
perf(s3reader): add seekable() method for DCP load optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+### Bug fixes
+* Add seekable() method in S3Reader to eliminate tensor copies during DCP loading (#359)
+
 ## v1.4.3 (July 25, 2025)
 
 ### New features

--- a/s3torchconnector/src/s3torchconnector/s3reader/s3reader.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/s3reader.py
@@ -41,6 +41,13 @@ class S3Reader(ABC, io.BufferedIOBase):
     def readinto(self, buf) -> int:
         pass
 
+    def seekable(self) -> bool:
+        """
+        Returns:
+            bool: Return whether object supports seek operations.
+        """
+        return True
+
     def readable(self) -> bool:
         """
         Returns:

--- a/s3torchconnector/tst/unit/test_s3reader_common.py
+++ b/s3torchconnector/tst/unit/test_s3reader_common.py
@@ -304,6 +304,26 @@ def test_seeks_end(reader_implementation: Type[S3Reader]):
     assert s3reader.readinto(buf) == 0
 
 
+def test_seekable(reader_implementation: Type[S3Reader]):
+    s3reader = reader_implementation(
+        TEST_BUCKET,
+        TEST_KEY,
+        lambda: None,
+        lambda: iter([]),
+    )
+    assert s3reader.seekable()
+
+
+def test_readable(reader_implementation: Type[S3Reader]):
+    s3reader = reader_implementation(
+        TEST_BUCKET,
+        TEST_KEY,
+        lambda: None,
+        lambda: iter([]),
+    )
+    assert s3reader.readable()
+
+
 def test_not_writable(reader_implementation: Type[S3Reader]):
     s3reader = reader_implementation(
         TEST_BUCKET,


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

- Add `seekable() `method returning True in S3Reader base class
- Add unit tests for `seekable` and `readable` methods

This allows us to eliminate PyTorch tensor copies during DCP loading.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

- Our `S3Reader` extends `io.BufferedIOBase` (in [cpython/Lib/_pyio.py](https://github.com/python/cpython/blob/main/Lib/_pyio.py)) which defaults `seekable()` to False. 
- During DCP loading, PyTorch's [filesystem.py](https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/filesystem.py) checks [if the stream is seekable](https://github.com/pytorch/pytorch/blob/379ebdaf5e2fbf387de297f673254d005e583b31/torch/distributed/checkpoint/filesystem.py#L885), and if not, creates an extra `io.BytesIO` buffer copy for each tensor to allow `torch.load` to seek around it. 
- By implementing `seekable()` and returning True, we eliminate this extra copy step, resulting in ~20% performance improvement in DCP load operations.

No breaking changes.

- [x] I have updated the CHANGELOG or README if appropriate

<!-- ## Related items -->
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->
Added unit tests for `seekable()` in test_s3reader_common.py

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
