### PR TITLE
fix(s3writer): override closed property and block writes after close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug fixes
 * Add seekable() method in S3Reader to eliminate tensor copies during DCP loading (#359)
+* Override S3Writer closed property and block writes after close (#360)
 
 ## v1.4.3 (July 25, 2025)
 

--- a/s3torchconnector/src/s3torchconnector/s3writer.py
+++ b/s3torchconnector/src/s3torchconnector/s3writer.py
@@ -51,7 +51,9 @@ class S3Writer(io.BufferedIOBase):
 
         Raises:
             S3Exception: An error occurred accessing S3.
+            ValueError: If the writer is closed.
         """
+        self._checkClosed()  # from python/cpython/Lib/_pyio.py
         if isinstance(data, memoryview):
             data = data.tobytes()
         self.stream.write(data)
@@ -69,6 +71,14 @@ class S3Writer(io.BufferedIOBase):
                 self._closed = True
                 self.stream.close()
 
+    @property
+    def closed(self) -> bool:
+        """
+        Returns:
+            bool: Return whether the object is closed.
+        """
+        return self._closed
+
     def flush(self):
         """No-op"""
         pass
@@ -83,9 +93,9 @@ class S3Writer(io.BufferedIOBase):
     def writable(self) -> bool:
         """
         Returns:
-            bool: Return whether object was opened for writing.
+            bool: Return whether object is open for writing.
         """
-        return True
+        return not self.closed
 
     def tell(self) -> int:
         """


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

S3Writer changes:
- Override closed property to reflect _closed flag instead of BufferedIOBase.__closed
- Update writable() to return False after S3Writer is closed
- When writing on closed streams, use python/cpython/Lib/_pyio.py _checkClosed() method to raise ValueError

These fixes improve correctness without changing normal behaviour.


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

Our [S3Writer](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/s3torchconnector/src/s3torchconnector/s3writer.py) extends io.BufferedIOBase (in [_pyio.py](https://github.com/python/cpython/blob/main/Lib/_pyio.py)), which has a [closed](https://github.com/python/cpython/blob/055827528fa50c9a7707792f5fe264c4e20c07e9/Lib/_pyio.py#L462) property that reflects __closed, and we did not override it to represent our attribute self._closed. PyTorch methods might be using these properties/methods - and we improve correctness in this PR to avoid possible inconsistencies.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

Added unit tests for these 3 changes. 

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
