### PR TITLE
fix(s3reader): clamp sequential reader seek position to EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Add seekable() method in S3Reader to eliminate tensor copies during DCP loading (#359)
 * Override S3Writer closed property and block writes after close (#360)
 
+* Fix SequentialS3Reader seek beyond EOF to clamp position to object size (#362)
+
 ## v1.4.3 (July 25, 2025)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Bug fixes
 * Add seekable() method in S3Reader to eliminate tensor copies during DCP loading (#359)
 * Override S3Writer closed property and block writes after close (#360)
-
 * Fix SequentialS3Reader seek beyond EOF to clamp position to object size (#362)
 
 ## v1.4.3 (July 25, 2025)

--- a/s3torchconnector/src/s3torchconnector/s3reader/sequential.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/sequential.py
@@ -173,6 +173,9 @@ class SequentialS3Reader(S3Reader):
         if offset > self._buffer_size():
             self._prefetch_to_offset(offset)
 
+        if self._size is not None:
+            offset = min(offset, self._size)
+
         self._position = self._buffer.seek(offset)
         return self._position
 

--- a/s3torchconnector/tst/conftest.py
+++ b/s3torchconnector/tst/conftest.py
@@ -19,7 +19,7 @@ READER_CONSTRUCTORS = [
 
 @pytest.fixture(
     params=READER_CONSTRUCTORS,
-    ids=["sequential", "range_based_buffered", "range_based_unbuffered"],
+    ids=["sequential", "range_based_with_buffer", "range_based_no_buffer"],
     scope="module",
 )
 def reader_constructor(request) -> S3ReaderConstructorProtocol:

--- a/s3torchconnector/tst/unit/test_s3reader_common.py
+++ b/s3torchconnector/tst/unit/test_s3reader_common.py
@@ -205,18 +205,23 @@ def test_s3reader_seek_beyond_eof_different_positions(
     Since we use `pos + stream_length + 1`, we will seek beyond eof for all 3 seek modes.
     """
     stream, positions = stream_and_positions
-    s3reader = create_s3reader(stream, reader_implementation)
-
     stream_length = sum(map(len, stream))
     assume(stream_length > 0)
 
     for pos in positions:
+        s3reader = create_s3reader(stream, reader_implementation)
+
         # +1 ensures beyond EOF, since we only get _size in sequential reader when reading beyond eof
         beyond_eof_pos = pos + stream_length + 1
-        s3reader.seek(beyond_eof_pos, whence)
+        seek_return = s3reader.seek(beyond_eof_pos, whence)
 
-        assert s3reader.tell() == stream_length
+        # Verify seek beyond EOF sets position to EOF
+        assert s3reader.tell() == seek_return == stream_length
         assert s3reader._size == stream_length
+
+        # Verify seeking back into file still works
+        seek_return = s3reader.seek(pos)
+        assert s3reader.tell() == seek_return == pos
 
 
 @given(bytestream_and_positions())
@@ -285,6 +290,7 @@ def test_s3reader_read_edge_cases(
     [
         ("Zero-length readinto from start", 0, 0, [b"0123456789ABCDEF"], 0, 0),
         ("Zero-length readinto from middle", 5, 0, [b"0123456789ABCDEF"], 0, 5),
+        ("Zero-length read from EOF", 16, 0, [b"0123456789ABCDEF"], 0, 16),
         ("Readinto near EOF", 10, 10, [b"0123456789ABCDEF"], 6, 16),
         ("Readinto beyond EOF", 16, 10, [b"0123456789ABCDEF"], 0, 16),
         ("Readinto from empty file", 0, 10, [], 0, 0),

--- a/s3torchconnector/tst/unit/test_s3reader_common.py
+++ b/s3torchconnector/tst/unit/test_s3reader_common.py
@@ -207,7 +207,6 @@ def test_s3reader_seek_beyond_eof_different_positions(
     stream, positions = stream_and_positions
     s3reader = create_s3reader(stream, reader_implementation)
 
-    bytesio = BytesIO(b"".join(stream))
     stream_length = sum(map(len, stream))
     assume(stream_length > 0)
 
@@ -215,7 +214,6 @@ def test_s3reader_seek_beyond_eof_different_positions(
         # +1 ensures beyond EOF, since we only get _size in sequential reader when reading beyond eof
         beyond_eof_pos = pos + stream_length + 1
         s3reader.seek(beyond_eof_pos, whence)
-        bytesio.seek(beyond_eof_pos, whence)
 
         assert s3reader.tell() == stream_length
         assert s3reader._size == stream_length


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

This PR fixes a SequentialS3Reader edge case bug when seeking beyond EOF, with no impact on normal seek operations.

Changes:
- In SequentialS3Reader.seek(), clamp offset to _size before updating self/buffer positions
- Add test coverage for seek beyond EOF scenarios

This prevents SequentialS3Reader from seeking beyond EOF in SEEK_SET / SEEK_CUR modes, matching docstring behaviour "When seeking beyond the end of the file, always stay at EOF."


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

- Sequential reader incorrectly handles seek operations beyond object size: `_size` parameter is updated in `_prefetch_to_offset`, but `s3reader._position` and `s3reader._reader._buffer` positions are not clamped to object size.
- This is due to `BytesIO` object allowing seeks beyond its current size and the line `self._position = self._buffer.seek(offset) `does not correctly clamp position to object size.

No breaking changes - does not affect normal seek operations within object size. 

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

Added / updated unit tests with EOF seek scenarios.

Tests that would fail without the fix:
- `test_seek_beyond_eof[SequentialS3Reader-0]` (SEEK_SET)
- `test_seek_beyond_eof[SequentialS3Reader-1]` (SEEK_CUR)
- `test_s3reader_read_edge_cases[SequentialS3Reader-Seek beyond EOF then read-20-10-stream5--16]`

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
