### PR TITLE
Adding thread_count parameter to S3StorageWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Add seekable() method in S3Reader to eliminate tensor copies during DCP loading (#359)
 * Override S3Writer closed property and block writes after close (#360)
 
+### Other changes
+* Added thread_count parameter to S3StorageWriter 
+
 ## v1.4.3 (July 25, 2025)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ REGION = "us-east-1"
 model = torchvision.models.resnet18()
 
 # Save distributed checkpoint to S3
-s3_storage_writer = S3StorageWriter(region=REGION, path=CHECKPOINT_URI)
+s3_storage_writer = S3StorageWriter(region=REGION, path=CHECKPOINT_URI) # optional thread_count parameter for number of I/O threads to write
 DCP.save(
     state_dict=model.state_dict(),
     storage_writer=s3_storage_writer,

--- a/s3torchconnector/src/s3torchconnector/dcp/s3_file_system.py
+++ b/s3torchconnector/src/s3torchconnector/dcp/s3_file_system.py
@@ -271,6 +271,7 @@ class S3StorageWriter(FileSystemWriter):
         path: str,
         s3client_config: Optional[S3ClientConfig] = None,
         prefix_strategy: Optional[S3PrefixStrategyBase] = None,
+        thread_count: int = 1,
         **kwargs,
     ) -> None:
         """
@@ -287,6 +288,7 @@ class S3StorageWriter(FileSystemWriter):
         super().__init__(
             path=path,
             sync_files=False,  # FIXME: setting this to True makes the run to fail (L#333: `os.fsync(stream.fileno())`)
+            thread_count=thread_count,
             **kwargs,
         )
         self.fs = S3FileSystem(region, s3client_config=s3client_config)  # type: ignore


### PR DESCRIPTION
## Summary
Added optional thread_count parameter to S3StorageWriter to allow users to configure the number of I/O threads for write operations.

## Changes
• **S3StorageWriter**: Added thread_count parameter (defaults to 1) to constructor
• **Documentation**: Updated README example to show the new optional parameter

## Usage
```python
# Use default single thread
s3_storage_writer = S3StorageWriter(region=REGION, path=CHECKPOINT_URI)

# Configure multiple I/O threads for better performance
s3_storage_writer = S3StorageWriter(region=REGION, path=CHECKPOINT_URI, thread_count=4)
```

This enhancement allows users to optimize write performance by configuring the number of concurrent I/O threads based on their specific use case and infrastructure.