### PR TITLE
ci: migrate from macos-13 to macos-15-intel image

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-22.04, macos-13, macos-14]
+        # macos-15-intel planned to end August 2027
+        runner: [ubuntu-22.04, macos-15-intel, macos-14]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         test-run:
           - name: "S3"
@@ -42,8 +43,8 @@ jobs:
             profile-role: ${{ vars.PROFILE_IAM_ROLE }}
             profile-bucket: ${{ vars.S3_EXPRESS_PROFILE_BUCKET }}
         exclude:
-          # For Python 3.13, PyTorch does not support macos-13/x86_64, only macos-14/arm64.
-          - runner: macos-13
+          # For Python 3.13, PyTorch does not support macos-15-intel/x86_64, only macos-14/arm64.
+          - runner: macos-15-intel
             python-version: "3.13"
           - runner: macos-14
             python-version: "3.8"
@@ -128,11 +129,11 @@ jobs:
           pytest s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py -n auto
 
       - name: Install DCP dependencies
-        if: matrix.runner != 'macos-13'
+        if: matrix.runner != 'macos-15-intel'
         run: |
           python -m pip install './s3torchconnector[dcp-test]'
       - name: Run s3torchconnector DCP e2e tests
-        if: matrix.runner != 'macos-13'
+        if: matrix.runner != 'macos-15-intel'
         run: |
           CI_REGION=${{ matrix.test-run.region }} \
           CI_BUCKET=${{ matrix.test-run.bucket }} \

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -70,7 +70,8 @@ jobs:
     name: Rust tests
     strategy:
       matrix:
-        runner: [ubuntu-22.04, macos-13]
+        # macos-15-intel planned to end August 2027
+        runner: [ubuntu-22.04, macos-15-intel]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,17 +45,18 @@ jobs:
 #          - runner: ubuntu-20.04
 #            kind: manylinux
 #            arch: x86_64
-          - runner: macos-13
+          # macos-15-intel planned to end August 2027
+          - runner: macos-15-intel
             kind: macosx
             arch: x86_64
           - runner: macos-14
             kind: macosx
             arch: arm64
-        # cp313 macos-13 (x86_64) is not supported by PyTorch
+        # cp313 macos-15-intel (x86_64) is not supported by PyTorch
         exclude:
           - python: cp313
             builder:
-              runner: macos-13
+              runner: macos-15-intel
               kind: macosx
               arch: x86_64
     permissions:


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

According to https://github.com/actions/runner-images/issues/13046
- macos-13 will have Github Actions brownouts starting November 4th, and will be unsupported by December 4th. 

This PR:
- upgrades from macos-13 to macos-15-intel.
- Note macos-15-intel planned to end August 2027.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

- [ ] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
https://github.com/actions/runner-images/issues/13046
> [macOS] The macOS 13 Ventura based runner images will begin deprecation on September 22nd and will be fully unsupported by December 4th for GitHub and ADO #13046

## Testing
<!-- Please describe how these changes were tested. -->
Build Wheels workflow: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/18220092432

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
