### PR TITLE
fix(test): fix AWS_IO_DNS_INVALID_NAME in multiprocess tests

### DIFF
--- a/s3torchconnector/tst/e2e/test_distributed_training.py
+++ b/s3torchconnector/tst/e2e/test_distributed_training.py
@@ -79,7 +79,11 @@ def dataloader_for_map(
     )
     sampler = DistributedSampler(dataset)
     dataloader = DataLoader(
-        dataset, batch_size=batch_size, num_workers=num_workers, sampler=sampler
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        sampler=sampler,
+        multiprocessing_context=mp.get_context(),
     )
     return dataloader
 
@@ -93,7 +97,12 @@ def dataloader_for_iterable(
         enable_sharding=True,
         reader_constructor=reader_constructor,
     )
-    dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=num_workers)
+    dataloader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        multiprocessing_context=mp.get_context(),
+    )
     return dataloader
 
 

--- a/s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py
+++ b/s3torchconnector/tst/e2e/test_e2e_s3_lightning_checkpoint.py
@@ -12,6 +12,7 @@ from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.demos import WikiText2
 from lightning.pytorch.plugins import AsyncCheckpointIO
 from torch.utils.data import DataLoader
+import torch.multiprocessing as mp
 
 from s3torchconnector import S3Checkpoint
 from s3torchconnector._s3client import S3Client
@@ -79,7 +80,9 @@ def test_delete_checkpoint(checkpoint_directory):
 def test_load_trained_checkpoint(checkpoint_directory):
     nonce = random.randrange(2**64)
     dataset = WikiText2(data_dir=Path(f"/tmp/data/{nonce}"))
-    dataloader = DataLoader(dataset, num_workers=3)
+    dataloader = DataLoader(
+        dataset, num_workers=3, multiprocessing_context=mp.get_context()
+    )
     model = LightningTransformer(vocab_size=dataset.vocab_size)
     trainer = L.Trainer(accelerator=LIGHTNING_ACCELERATOR, fast_dev_run=2)
     trainer.fit(model=model, train_dataloaders=dataloader)
@@ -95,7 +98,9 @@ def test_load_trained_checkpoint(checkpoint_directory):
 def test_compatibility_with_trainer_plugins(checkpoint_directory):
     nonce = random.randrange(2**64)
     dataset = WikiText2(data_dir=Path(f"/tmp/data/{nonce}"))
-    dataloader = DataLoader(dataset, num_workers=3)
+    dataloader = DataLoader(
+        dataset, num_workers=3, multiprocessing_context=mp.get_context()
+    )
     model = LightningTransformer(vocab_size=dataset.vocab_size)
     s3_lightning_checkpoint = S3LightningCheckpoint(region=checkpoint_directory.region)
     _verify_user_agent(s3_lightning_checkpoint)
@@ -121,7 +126,9 @@ def test_compatibility_with_trainer_plugins(checkpoint_directory):
 def test_compatibility_with_checkpoint_callback(checkpoint_directory):
     nonce = random.randrange(2**64)
     dataset = WikiText2(data_dir=Path(f"/tmp/data/{nonce}"))
-    dataloader = DataLoader(dataset, num_workers=3)
+    dataloader = DataLoader(
+        dataset, num_workers=3, multiprocessing_context=mp.get_context()
+    )
 
     model = LightningTransformer(vocab_size=dataset.vocab_size)
     s3_lightning_checkpoint = S3LightningCheckpoint(checkpoint_directory.region)
@@ -161,7 +168,9 @@ def test_compatibility_with_checkpoint_callback(checkpoint_directory):
 def test_compatibility_with_async_checkpoint_io(checkpoint_directory):
     nonce = random.randrange(2**64)
     dataset = WikiText2(data_dir=Path(f"/tmp/data/{nonce}"))
-    dataloader = DataLoader(dataset, num_workers=3)
+    dataloader = DataLoader(
+        dataset, num_workers=3, multiprocessing_context=mp.get_context()
+    )
 
     model = LightningTransformer(vocab_size=dataset.vocab_size)
     s3_lightning_checkpoint = S3LightningCheckpoint(checkpoint_directory.region)
@@ -192,7 +201,9 @@ def test_compatibility_with_async_checkpoint_io(checkpoint_directory):
 def test_compatibility_with_lightning_checkpoint_load(checkpoint_directory):
     nonce = random.randrange(2**64)
     dataset = WikiText2(data_dir=Path(f"/tmp/data/{nonce}"))
-    dataloader = DataLoader(dataset, num_workers=3)
+    dataloader = DataLoader(
+        dataset, num_workers=3, multiprocessing_context=mp.get_context()
+    )
     model = LightningTransformer(vocab_size=dataset.vocab_size)
     s3_lightning_checkpoint = S3LightningCheckpoint(region=checkpoint_directory.region)
     trainer = L.Trainer(

--- a/s3torchconnector/tst/e2e/test_multiprocess_dataloading.py
+++ b/s3torchconnector/tst/e2e/test_multiprocess_dataloading.py
@@ -10,6 +10,7 @@ from typing import Callable, TYPE_CHECKING
 import pytest
 from torch.utils.data import DataLoader, get_worker_info
 from torchdata.datapipes.iter import IterableWrapper
+import torch.multiprocessing as mp
 
 from s3torchconnector import (
     S3IterableDataset,
@@ -85,7 +86,12 @@ def test_s3iterable_dataset_multiprocess_torchdata(
     batch_size = 2
     num_workers = 3
 
-    dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=num_workers)
+    dataloader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        multiprocessing_context=mp.get_context(),
+    )
 
     total_objects = 0
     uris_seen = Counter()
@@ -123,7 +129,9 @@ def test_s3iterable_dataset_multiprocess(
     num_epochs = 2
     num_images = len(image_directory.contents)
 
-    dataloader = DataLoader(dataset, num_workers=num_workers)
+    dataloader = DataLoader(
+        dataset, num_workers=num_workers, multiprocessing_context=mp.get_context()
+    )
     counter = 0
     for epoch in range(num_epochs):
         s3keys = Counter()
@@ -160,7 +168,9 @@ def test_s3mapdataset_multiprocess(
     num_epochs = 2
     num_images = len(image_directory.contents)
 
-    dataloader = DataLoader(dataset, num_workers=num_workers)
+    dataloader = DataLoader(
+        dataset, num_workers=num_workers, multiprocessing_context=mp.get_context()
+    )
 
     for epoch in range(num_epochs):
         s3keys = Counter()

--- a/s3torchconnectorclient/python/tst/integration/test_logging.py
+++ b/s3torchconnectorclient/python/tst/integration/test_logging.py
@@ -1,6 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
 import os.path
+import platform
 import sys
 import tempfile
 from typing import List
@@ -180,7 +181,7 @@ def _start_subprocess(
     debug_logs_config: str = "",
     logs_directory: str = "",
 ):
-    process = subprocess.Popen(
+    result = subprocess.run(
         [
             sys.executable,
             "-c",
@@ -190,11 +191,10 @@ def _start_subprocess(
             debug_logs_config,
             logs_directory,
         ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
-    return process.communicate()
+    return result.stdout, result.stderr
 
 
 def _read_log_file(log_file: str):


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

- Add `multiprocessing_context=mp.get_context()` to force DataLoader to use the same context as the main process (i.e. spawn instead of fork on Darwin) for multiprocessing e2e tests, 
- Prevents S3 client fork handlers from corrupting AWS CRT DNS resolver threads on macOS GitHub runners.

Alternatively, we can also consider changing behaviour on S3Client's fork handlers specifically on Darwin platform.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

#### Error Context

Tests were failing with `AWS_IO_DNS_INVALID_NAME` errors on macos-14 (ARM64) GitHub Actions runners during our Build Wheels workflow, particularly in `test_distributed_training.py`. These errors were intermittent, across 5 macos-14 runners each running 40+ tests, typically 1-2 fails. We could resolve these failures by retrying the Build Wheels workflow 1-2 times for every run. 

The error re-appeared in PR [#374](https://github.com/awslabs/s3-connector-for-pytorch/pull/374). The error stack traces showed `popen_fork.py` being used, which was suspicious since we were explicitly setting `torch.multiprocessing.set_start_method('spawn')`, and disabled fork / forkserver methods for Darwin. 

#### Root Cause (Still Investigating)

PyTorch DataLoader source code (torch/utils/data/dataloader.py) showed that when `multiprocessing_context=None` (the default), DataLoader ignores the global `torch.multiprocessing.set_start_method()` setting and uses its own default context. This means DataLoader was using fork internally, triggering the S3 client's fork handlers.

When DataLoader forks workers, S3 client fork handlers (registered via `os.register_at_fork()` as a workaround for CRT multithreading issues in PR [#320](https://github.com/awslabs/s3-connector-for-pytorch/pull/320)) call `join_all_managed_threads()` to clean up AWS CRT background threads, but this corrupts active DNS resolver threads and causes `AWS_IO_DNS_INVALID_NAME` errors.

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
- Related PR with errors: https://github.com/awslabs/s3-connector-for-pytorch/pull/374
- PR for workaround for fork: https://github.com/awslabs/s3-connector-for-pytorch/pull/320

## Testing
<!-- Please describe how these changes were tested. -->
Build Wheels workflow: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/18225016406

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
