### PR TITLE
feat(dcp): list of ranges reader for DCP partial loading

### DIFF
--- a/s3torchconnector/src/s3torchconnector/s3reader/__init__.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/__init__.py
@@ -2,9 +2,10 @@
 #  // SPDX-License-Identifier: BSD
 
 from .s3reader import S3Reader
-from .constructor import S3ReaderConstructor
+from .constructor import S3ReaderConstructor, DCPListOfRangesConstructor
 from .sequential import SequentialS3Reader
 from .ranged import RangedS3Reader
+from .list_of_ranges import ListOfRangesS3Reader
 from .protocol import GetStreamCallable, S3ReaderConstructorProtocol
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "S3ReaderConstructor",
     "SequentialS3Reader",
     "RangedS3Reader",
+    "ListOfRangesS3Reader",
 ]

--- a/s3torchconnector/src/s3torchconnector/s3reader/constructor.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/constructor.py
@@ -2,11 +2,12 @@
 #  // SPDX-License-Identifier: BSD
 
 from functools import partial
-from typing import Optional
+from typing import Optional, List
 
 from .protocol import S3ReaderConstructorProtocol
 from .sequential import SequentialS3Reader
 from .ranged import RangedS3Reader
+from .list_of_ranges import ListOfRangesS3Reader, RangeRequest
 
 
 class S3ReaderConstructor:
@@ -24,7 +25,10 @@ class S3ReaderConstructor:
     """
 
     @staticmethod
-    def sequential() -> S3ReaderConstructorProtocol:
+    def sequential(
+        start_offset: Optional[int] = None,
+        end_offset: Optional[int] = None,
+    ) -> S3ReaderConstructorProtocol:
         """Creates a constructor for sequential readers
 
         Returns:
@@ -35,7 +39,12 @@ class S3ReaderConstructor:
             reader_constructor = S3ReaderConstructor.sequential()
 
         """
-        return partial(SequentialS3Reader)
+        # TODO update docstrings (after implementation fixed)
+        return partial(
+            SequentialS3Reader,
+            start_offset=start_offset,
+            end_offset=end_offset,
+        )
 
     @staticmethod
     def range_based(buffer_size: Optional[int] = None) -> S3ReaderConstructorProtocol:
@@ -79,6 +88,12 @@ class S3ReaderConstructor:
         return partial(RangedS3Reader, buffer_size=buffer_size)
 
     @staticmethod
+    def list_of_ranges(ranges: List[RangeRequest]) -> S3ReaderConstructorProtocol:
+        """Creates a constructor for ListOfRangesS3Reader with specific ranges"""
+        # TODO update docstring
+        return partial(ListOfRangesS3Reader, ranges=ranges)
+
+    @staticmethod
     def default() -> S3ReaderConstructorProtocol:
         """Creates default reader constructor (sequential)
 
@@ -104,5 +119,7 @@ class S3ReaderConstructor:
             return "range_based"
         elif constructor.func == SequentialS3Reader:
             return "sequential"
+        elif constructor.func == ListOfRangesS3Reader:
+            return "list_of_ranges"
         else:
             return "unknown"

--- a/s3torchconnector/src/s3torchconnector/s3reader/list_of_ranges.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/list_of_ranges.py
@@ -1,0 +1,165 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  // SPDX-License-Identifier: BSD
+
+import os
+import logging
+from dataclasses import dataclass
+from typing import List, Optional, Callable, Union, Dict
+from io import SEEK_SET
+
+from s3torchconnectorclient._mountpoint_s3_client import (
+    ObjectInfo,
+    GetObjectStream,
+    HeadObjectResult,
+)
+from .s3reader import S3Reader
+from .sequential import SequentialS3Reader
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class RangeRequest:
+    start: int
+    end: int
+    request_id: Optional[str] = None
+
+
+@dataclass
+class RangeGroup:
+    start: int
+    end: int
+    requests: List[RangeRequest]
+
+
+class ListOfRangesS3Reader(S3Reader):
+    """Optimized reader with pre-calculated request mapping and batch prefetch."""
+
+    def __init__(
+        self,
+        bucket: str,
+        key: str,
+        ranges: List[RangeRequest],
+        get_object_info: Callable[[], Union[ObjectInfo, HeadObjectResult]],
+        get_stream: Callable[[Optional[int], Optional[int]], GetObjectStream],
+        max_gap_size: int = 200 * 1024 * 1024,
+        **kwargs,
+    ):
+        self._bucket = bucket
+        self._key = key
+        self._get_object_info = get_object_info
+        self._get_stream = get_stream
+
+        # Calculate range groups using coalescing logic
+        self._range_groups = self._calculate_range_groups(ranges, max_gap_size)
+
+        # Pre-create all readers and prefetch immediately
+        # TODO - judge if this is beneficial or not.
+        self._group_readers: Dict[int, SequentialS3Reader] = {}
+        for i, group in enumerate(self._range_groups):
+            reader = SequentialS3Reader(
+                bucket=bucket,
+                key=key,
+                get_object_info=get_object_info,
+                get_stream=get_stream,
+                start_offset=group.start,
+                end_offset=group.end,
+            )
+            reader.prefetch()  # Batch prefetch all ranges
+            self._group_readers[i] = reader
+
+        # Pre-calculate request-to-reader mapping
+        self._request_to_reader: Dict[int, int] = {}
+        for i, group in enumerate(self._range_groups):
+            for request in group.requests:
+                self._request_to_reader[request.start] = i
+
+        self._current_position = 0
+
+    @property
+    def bucket(self) -> str:
+        return self._bucket
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def _calculate_range_groups(
+        self, ranges: List[RangeRequest], max_gap_size: int
+    ) -> List[RangeGroup]:
+        """Coalescing logic - group ranges within max_gap_size."""
+        # TODO: optimise this logic
+        if not ranges:
+            return []
+
+        sorted_ranges = sorted(ranges, key=lambda r: r.start)
+        groups = []
+        current_group = [sorted_ranges[0]]
+
+        for i in range(1, len(sorted_ranges)):
+            prev_end = current_group[-1].end
+            curr_start = sorted_ranges[i].start
+
+            if curr_start - prev_end <= max_gap_size:
+                current_group.append(sorted_ranges[i])
+            else:
+                groups.append(self._create_range_group(current_group))
+                current_group = [sorted_ranges[i]]
+
+        groups.append(self._create_range_group(current_group))
+        return groups
+
+    def _create_range_group(self, ranges: List[RangeRequest]) -> RangeGroup:
+        """Create range group - always succeeds since we only use gap size."""
+        # TODO remove min/max code by tracking incrementally in _calculate_range_groups
+        # * (was kept since it's easier to understand and test)
+        group_start = min(r.start for r in ranges)
+        group_end = max(r.end for r in ranges)
+        return RangeGroup(start=group_start, end=group_end, requests=ranges)
+
+    def get_reader_for_request(
+        self, request_start: int
+    ) -> Optional[SequentialS3Reader]:
+        """O(1) lookup using pre-calculated mapping."""
+        reader_idx = self._request_to_reader.get(request_start)
+        return self._group_readers.get(reader_idx) if reader_idx is not None else None
+
+    def _find_reader_for_offset(self, offset: int) -> Optional[SequentialS3Reader]:
+        """Find reader that contains the given offset."""
+        # TODO: improve logic using binary search
+        for reader in self._group_readers.values():
+            if reader._start_offset <= offset < reader._end_offset:
+                return reader
+            elif reader._start_offset > offset:
+                break  # Early termination since readers are ordered
+        return None
+
+    def seek(self, offset: int, whence: int = SEEK_SET, /) -> int:
+        self._current_position = offset
+        reader = self._find_reader_for_offset(offset)
+        if not reader:
+            return self._current_position
+        reader.seek(offset, whence)
+
+    def read(self, size: Optional[int] = None) -> bytes:
+        reader = self._find_reader_for_offset(self._current_position)
+        if not reader:
+            return b""
+        data = reader.read(size)
+        self._current_position += len(data)
+        return data
+
+    def readinto(self, buf) -> int:
+        reader = self._find_reader_for_offset(self._current_position)
+        if not reader:
+            return 0
+        bytes_read = reader.readinto(buf)
+        self._current_position += bytes_read
+        return bytes_read
+
+    def tell(self) -> int:
+        return self._current_position
+
+    def close(self) -> None:
+        for reader in self._group_readers.values():
+            reader.close()


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

ListOfRangesS3Reader for DCP Partial Loading: Implements ListOfRangesS3Reader to optimize PyTorch Distributed Checkpoint (DCP) partial loading by only fetching required byte ranges instead of entire objects.

- ListOfRangesS3Reader: Coalesces nearby ranges and manages multiple ranged streams per object
- Enhanced SequentialS3Reader: Added start_offset / end_offset support for ranged reads (This blurs boundary between sequential/range-based readers - to check if this is the best way to implement)
- DCP Integration: S3StorageReader automatically injects range metadata from DCP load plans when providing `dcp_list_of_ranges()` as reader_constructor

Usage:
```python
reader_constructor = S3ReaderConstructor.dcp_list_of_ranges()
storage_reader = S3StorageReader(region, path, reader_constructor=reader_constructor)
```

Optimized for partial DCP loading where only specific items are needed from large distributed checkpoint files.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->


- [ ] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
