### PR TITLE
ci: add missing permissions to Github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
     types: [ "checks_requested" ]
 
+permissions:
+  contents: read
+
 jobs:
   rust-checks:
     name: Rust Checks

--- a/.github/workflows/generate_third_party_licenses.yml
+++ b/.github/workflows/generate_third_party_licenses.yml
@@ -10,6 +10,9 @@ on:
         description: "The created artifact name for ORT results"
         value: ${{ jobs.generate_third_party_licenses.outputs.artifact_name }}
 
+permissions:
+  contents: read
+
 jobs:
   generate_third_party_licenses:
     name: Generate NOTICE_DEFAULT file

--- a/.github/workflows/notify-comment.yml
+++ b/.github/workflows/notify-comment.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-issue.yml
+++ b/.github/workflows/notify-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, reopened, edited]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-wheel-failure.yml
+++ b/.github/workflows/notify-wheel-failure.yml
@@ -6,6 +6,9 @@ on:
       - Build Wheels
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -9,6 +9,10 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
@@ -63,9 +67,7 @@ jobs:
             python-version: "3.11"
           - runner: macos-14
             python-version: "3.12"
-    permissions:
-      id-token: write
-      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -3,6 +3,9 @@ name: Rust Checks
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,10 @@ on:
     branches: [ "dependabot/*", "main", "workflow/*" ]
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   S3_REGION: ${{ vars.S3_REGION }}
   S3_BUCKET: ${{ vars.S3_BUCKET }}
@@ -58,9 +62,6 @@ jobs:
               runner: macos-13
               kind: macosx
               arch: x86_64
-    permissions:
-      id-token: write
-      contents: read
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Add permission blocks to all GitHub workflows to resolve [CodeQL security findings](https://github.com/awslabs/s3-connector-for-pytorch/security/code-scanning).

- `contents: read` for 8 workflows.
- `id-token: write` + `contents: read` for wheels and python-integration workflows.
  - removed job-level permission blocks and gave required permissions in top level for easier maintenance.
  - Note: `configure-aws-credentials` action needs `id_token: write permissions`

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->


- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
