### PR TITLE
fix: use memoryview for unbuffered read with ranged S3 reader (#380)

### DIFF
--- a/s3torchconnector/src/s3torchconnector/s3reader/ranged.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/ranged.py
@@ -148,7 +148,8 @@ class RangedS3Reader(S3Reader):
         for chunk in self._get_stream(start, end):
             # Safeguard for buffer overflow (stream size > length)
             chunk_size = min(len(chunk), length - bytes_read)
-            view[bytes_read : bytes_read + chunk_size] = chunk[:chunk_size]
+            chunk_view = memoryview(chunk)
+            view[bytes_read : bytes_read + chunk_size] = chunk_view[:chunk_size]
             bytes_read += chunk_size
             # Exit if finished reading
             if bytes_read == length:

--- a/s3torchconnector/tst/unit/test_s3reader_range_based.py
+++ b/s3torchconnector/tst/unit/test_s3reader_range_based.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from io import BytesIO, SEEK_END, SEEK_CUR
 from typing import List, Tuple
-from unittest.mock import Mock
+from unittest.mock import Mock, patch, call
 
 import pytest
 from hypothesis import given, assume
@@ -44,12 +44,12 @@ BUFFER_BEHAVIOR_TEST_CASES = [
 ]
 
 
-def create_range_s3reader(stream, buffer_size=None):
+def create_range_s3reader(stream, buffer_size=None, chunk_size=5):
     return RangedS3Reader(
         TEST_BUCKET,
         TEST_KEY,
         create_object_info_getter(stream),
-        create_stream_getter(stream),
+        create_stream_getter(stream, chunk_size=chunk_size),
         buffer_size=buffer_size,
     )
 
@@ -124,6 +124,22 @@ def test_s3reader_readinto_invalid_buffer(invalid_buf):
         TypeError, match="argument must be a writable bytes-like object"
     ):
         s3reader.readinto(invalid_buf)
+
+
+def test_read_unbuffered_uses_memoryview_for_chunks():
+    """Test that _read_unbuffered uses memoryview to avoid bytes slicing copies"""
+
+    chunk = b"0123456789"
+    s3reader = create_range_s3reader([chunk], buffer_size=0, chunk_size=10)
+
+    with patch(
+        "s3torchconnector.s3reader.ranged.memoryview", side_effect=memoryview
+    ) as mock_memoryview:
+        buf = bytearray(10)
+        view = memoryview(buf)
+        s3reader._read_unbuffered(view, 0, 10)
+
+    assert call(chunk) in mock_memoryview.call_args_list
 
 
 # Buffer Behaviour Tests


### PR DESCRIPTION
## Description
See #380 
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->


- [x] I have updated the CHANGELOG or README if appropriate

## Related items
#380 

## Testing
[x] Added a new unit test

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
