### PR TITLE
fix(test): use raw string to avoid syntax warning

### DIFF
--- a/s3torchconnector/tst/unit/test_user_agent.py
+++ b/s3torchconnector/tst/unit/test_user_agent.py
@@ -39,5 +39,5 @@ def test_default_user_agent_creation():
 
 @pytest.mark.parametrize("invalid_comment", [0, "string"])
 def test_invalid_comments_argument(invalid_comment):
-    with pytest.raises(ValueError, match="Argument comments must be a List\[str\]"):
+    with pytest.raises(ValueError, match=r"Argument comments must be a List\[str\]"):
         UserAgent(invalid_comment)


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Avoids `SyntaxWarning: invalid escape sequence '\['`, which is warned by mypy and also pytest. 

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

## Testing
<!-- Please describe how these changes were tested. -->

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
