### PR TITLE
fix(lightning): temporarily restrict lightning version to <2.6

### DIFF
--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -47,7 +47,7 @@ e2e = [
 ]
 
 lightning = [
-    "lightning >= 2.0"
+    "lightning >= 2.0, <2.6" # FIXME: temporarily restrict until we implement weights_only support for S3LightningCheckpoint.load_checkpoint().
 ]
 
 lightning-tests = [


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

**Problem**: Lightning 2.6.0 added `weights_only` parameter to `CheckpointIO.load_checkpoint()`, causing TypeError when using `S3LightningCheckpoint.load_checkpoint()` which doesn't support this parameter. [Self-cut issue #387](https://github.com/awslabs/s3-connector-for-pytorch/issues/387).

**Mitigation**: Constraint Lightning version to < 2.6 temporarily to unblock CI pipeline. This is urgent since we want to unblock CI pipeline before [macos-13 deprecation fix](https://github.com/awslabs/s3-connector-for-pytorch/pull/374) is complete, which would otherwise start blocking pipeline from December 4th. 

**To follow-up with fix**: [feat(lightning): add weights_only parameter support for Lightning 2.6.0 #388
 ](https://github.com/awslabs/s3-connector-for-pytorch/pull/388)


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->


- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
- Self-cut issue: https://github.com/awslabs/s3-connector-for-pytorch/issues/387
- Follow-up PR: https://github.com/awslabs/s3-connector-for-pytorch/pull/388

## Testing
<!-- Please describe how these changes were tested. -->
Unit and integration tests pass.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
