### PR TITLE
ci: fix Python 3.13 wheel build failure with system OpenSSL

### DIFF
--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -110,7 +110,7 @@ manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 before-all = [
   "yum -y update",
-  "yum -y install openssl3 openssl3-devel",
+  "yum -y install openssl-devel",
   "yum install -y gcc-toolset-10-gcc",
   "yum install -y gcc-toolset-10-gcc-c++",
   "yum install -y clang clang-devel llvm-toolset",


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

This PR fixes build failure error: `nothing provides fips-provider-so needed by openssl3-libs-3.5.1-6.1.el8.x86_64 from epel` (e.g. in [this wheel build failure](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/20232956244/job/58080592296)).

Use system OpenSSL (1.1.1k) instead of openssl3 from EPEL to resolve missing fips-provider-so dependency. This seems to be the intended behavior as referenced in https://github.com/pypa/manylinux/issues/1560 - it's an old issue but in [build-openssl.sh](https://github.com/pypa/manylinux/blob/main/docker/build_scripts/build-openssl.sh), "manylinux does not rebuild OpenSSL if the system OpenSSL is new enough (>= 1.1.1)", so it still applies to current build (under `Run python -m` in [this wheel build success](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/20236057400/job/58091398373)).

The `openssl-devel` package should provide development headers for Rust dependencies which need OpenSSL (I think mainly the ring crate in deny.toml).

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

- [x] I have updated the CHANGELOG or README if appropriate - not required, ci changes only.

## Related items
<!-- Please add related pull requests or Github issues. -->

- https://github.com/pypa/manylinux/issues/1560

## Testing
<!-- Please describe how these changes were tested. -->
Build Wheels workflow: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/20236057400

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
