### PR TITLE
fix(ci): workaround torch-2.10.0-1 macOS wheels hang

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -109,8 +109,11 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          # Manually install CPU-only version of torch so we're not carrying around giant GPU drivers/kernels
           python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
+          # Workaround for torch-2.10.0-1 macOS wheels missing executable permission on torch_shm_manager
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            chmod +x $(python -c "import torch; print(torch.__path__[0])")/bin/torch_shm_manager || true
+          fi
           python -m pip install -e "s3torchconnectorclient[test,e2e]"
           python -m pip install -e "s3torchconnector[test,e2e]"
 

--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -51,6 +51,8 @@ license-files = [ "LICENSE", "THIRD-PARTY-LICENSES", "NOTICE"]
 test-requires = ["./s3torchconnector[e2e]"]
 test-extras = "test"
 test-command = [
+    # Workaround for torch-2.10.0-1 macOS wheels missing executable permission on torch_shm_manager
+    "chmod +x $(python -c \"import torch; print(torch.__path__[0])\")/bin/torch_shm_manager || true",
     "pytest {package}/python/tst/unit",
     "pytest {package}/../s3torchconnector/tst/unit --ignore {package}/../s3torchconnector/tst/unit/lightning --ignore {package}/../s3torchconnector/tst/unit/dcp",
     "CI_STORAGE_CLASS='' CI_REGION=${S3_REGION} CI_BUCKET=${S3_BUCKET} CI_PREFIX=${S3_PREFIX} CI_CUSTOM_ENDPOINT_URL=${S3_CUSTOM_ENDPOINT_URL} CI_PROFILE_ROLE=${PROFILE_IAM_ROLE} CI_PROFILE_BUCKET=${S3_PROFILE_BUCKET} pytest {package}/python/tst/integration",


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

The torch-2.10.0-1 wheel rebuilds' `torch_shm_manager` doesn't seem to have the executable bit set, causing multiprocessing DataLoader tests to hang. Add `chmod +x` on `torch/bin/torch_shm_manager` as a workaround.

If this fix is not strong enough (i.e. there might be other regressions in torch-2.10.0-1), we may force install specific wheels, e.g. `pip install https://download.pytorch.org/whl/cpu/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl`, for both `python-integration.yml` and `s3torchconnectorclient`'s `pyproject.toml`. Track upstream issue to monitor: https://github.com/pytorch/pytorch/issues/174680.

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

<details>
<summary>Further context to this regression and relevant investigations (Click to expand)</summary>

Integration tests for macos-14 (Python 3.13, S3) failed over the weekend:
- Feb 6, 2026 Success: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/21756835604/job/62769364734
- Feb 9, 2026 Fail: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/21821855516/job/62956933541

Diffing the 2 logs together gives these differences:
| Component      | [Succeeding](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/21756835604/job/62769364734)                                             | [Failing](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/21821855516/job/62956933541)                                                                             |
| -------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------- |
| PyTorch wheel  | torch-2.10.0-cp313-none-macosx_11_0_arm64.whl (cached) | torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl (fresh download, -1 build revision) |
| setuptools     | 80.10.2                                                | 82.0.0                                                                              |
| boto3/botocore | 1.42.43                                                | 1.42.44                                                                             |
| Cargo cache    | Cache miss                                             | Cache hit                                                                           |

The main change that would cause this regression would be the change in PyTorch wheel for macOS torch-2.10.0 with the `-1` addition (see all available wheels in [PyPI](https://pypi.org/project/torch/#files), or [PyTorch's index](https://download.pytorch.org/whl/cpu/torch/) which is applicable when running `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu`). 

Manually triggering [Build Wheels](https://github.com/awslabs/s3-connector-for-pytorch/actions/workflows/wheels.yml) workflow gives us a clearer view that `test_multiprocess_dataloading.py` was the test that failed: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/21831382368/job/62991063402

Running locally gives this error in `test_s3iterable_dataset_multiprocess`(running with `pytest-xdist`, i.e. `-n auto`, does not reproduce it):
```
RuntimeError: torch_shm_manager at "<venv>/lib/python3.13/site-packages/torch/bin/torch_shm_manager": execl failed: Permission denied
Exception raised from start_manager at /Users/runner/work/pytorch/pytorch/pytorch/torch/lib/libshm/core.cpp:67 (most recent call first):
```

It seems running `chmod +x venv/lib/python3.13/site-packages/torch/bin/torch_shm_manager` can resolve this test hang. So I edited `python-integration.yml` and s3torchconnectorclient's `pyproject.toml` (what `wheels.yml` runs) to chmod +x on the relevant file. (Adding before-all line in [tool.cibuildwheel.macos] didn't seem to work, could be because of all the overrides).

</details>

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

- Upstream issue: https://github.com/pytorch/pytorch/issues/174680

## Testing
<!-- Please describe how these changes were tested. -->
Integration Tests: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/21870575268
Build Wheels workflow: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/21870568282

Note that 'Integration tests (PR)' would still be using the old python-integration.yml file and the Python 3.13 tests (only tests that use the -1 wheels) are expected to fail. 'Integration tests (Main)' should pass. 

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
