### PR TITLE
fix(ci): add s3torchconnector[test] to cibuildwheel test-requires

### DIFF
--- a/s3torchconnectorclient/pyproject.toml
+++ b/s3torchconnectorclient/pyproject.toml
@@ -48,7 +48,7 @@ target = "s3torchconnectorclient._mountpoint_s3_client"
 license-files = [ "LICENSE", "THIRD-PARTY-LICENSES", "NOTICE"]
 
 [tool.cibuildwheel]
-test-requires = ["./s3torchconnector[e2e]"]
+test-requires = ["./s3torchconnector[test,e2e]"]
 test-extras = "test"
 test-command = [
     "pytest {package}/python/tst/unit",


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Include s3torchconnector[test] extra in addition to s3torchconnectorclient[test] in test-extras line, required by PyTorch 2.7.0+ DCP imports in `test_s3reader_constructor.py` which imports some PyTorch DCP packages.

The original test-extra line only covers s3torchconnectorclient[test], and since it used to be identical to s3torchconnector[test] previous tests were passing. 

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

When developing https://github.com/awslabs/s3-connector-for-pytorch/pull/378 we added `importlib_metadata` dependency in test extra, the integration tests pass but Build Wheels is failing with:
```
ImportError while importing test module '/Users/runner/work/s3-connector-for-pytorch/s3-connector-for-pytorch/s3torchconnector/tst/unit/test_s3reader_constructor.py'. 
```

This error wasn't caught in python-integration tests since integration test implementation uses `python -m pip install -e "s3torchconnector[test,e2e]"` (the correct import). I couldn't have verified Build Wheels workflow success since it was a branch in a forked repo which the workflow's `workflow_dispatch` line doesn't cover. 

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
- PR that caused issue: https://github.com/awslabs/s3-connector-for-pytorch/pull/378

## Testing
<!-- Please describe how these changes were tested. -->
- Build Wheels workflow for this PR: https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/22058882695

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
