### PR TITLE
feat(dcp): make DCPOptimizedS3Reader the default for S3StorageReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v1.5.0 (February 17, 2026)
 
 ### New features
-* Add DCPOptimizedS3Reader as new default for faster and partial DCP loading (#378) (#TODO)
+* Add DCPOptimizedS3Reader as new default for faster and partial DCP loading (#378, #419)
 * Add support for Python 3.14 (#408)
 * Add weights_only parameter support for Lightning 2.6.0 compatibility (#388)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,18 +19,18 @@
 * Add macOS x86_64 and Python 3.8 deprecation warnings (#400)
 
 ### Breaking changes
-* No breaking changes, but DCPOptimizedS3Reader as the new default reader for `S3StorageReader` might lead to behavioral changes. See [Troubleshooting DCPOptimizedS3Reader](https://github.com/awslabs/s3-connector-for-pytorch/?tab=readme-ov-file#troubleshooting-dcpoptimizeds3reader) section in README for more details. 
+* No breaking changes, but DCPOptimizedS3Reader as the new default reader for `S3StorageReader` might lead to behavioral changes. See [DCPOptimizedS3Reader Errors](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/docs/TROUBLESHOOTING.md#dcpoptimizeds3reader-errors) for more details.
 
 ## v1.4.3 (July 25, 2025)
 
 ### New features
-* Add support for Python 3.13 (#350
+* Add support for Python 3.13 (#350)
 
 ### Other changes
 * Modify test fixtures to mitigate CI/CD S3Express boto3 400 errors (#347)
 * Add profile config guide and improve docs (#349)
 
-### Breaking change
+### Breaking changes
 * No breaking changes.
 
 ## v1.4.2 (July 14, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v1.5.0 (February 17, 2026)
 
 ### New features
-* Add DCPOptimizedS3Reader for faster and partial DCP loading (#378)
+* Add DCPOptimizedS3Reader as new default for faster and partial DCP loading (#378) (#TODO)
 * Add support for Python 3.14 (#408)
 * Add weights_only parameter support for Lightning 2.6.0 compatibility (#388)
 
@@ -19,18 +19,18 @@
 * Add macOS x86_64 and Python 3.8 deprecation warnings (#400)
 
 ### Breaking changes
-* No breaking changes.
+* No breaking changes, but DCPOptimizedS3Reader as the new default reader for `S3StorageReader` might lead to behavioral changes. See [Troubleshooting DCPOptimizedS3Reader](https://github.com/awslabs/s3-connector-for-pytorch/?tab=readme-ov-file#troubleshooting-dcpoptimizeds3reader) section in README for more details. 
 
 ## v1.4.3 (July 25, 2025)
 
 ### New features
-* Add support for Python 3.13 (#350)
+* Add support for Python 3.13 (#350
 
 ### Other changes
 * Modify test fixtures to mitigate CI/CD S3Express boto3 400 errors (#347)
 * Add profile config guide and improve docs (#349)
 
-### Breaking changes
+### Breaking change
 * No breaking changes.
 
 ## v1.4.2 (July 14, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.5.0 (February 17, 2026)
+## v1.5.0 (February 20, 2026)
 
 ### New features
 * Add DCPOptimizedS3Reader as new default for faster and partial DCP loading (#378, #419)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Amazon S3 Connector for PyTorch provides robust support for PyTorch distributed 
 - `S3StorageReader`: Implementation of PyTorch's StorageReader interface. 
   - Supports configurable reading strategies via the `reader_constructor` parameter (see [Reader Configurations](#reader-configurations)). 
   - Uses `DCPOptimizedS3Reader` by default for faster loading and partial checkpoint optimizations. 
+  - Please refer to [DCPOptimizedS3Reader Errors](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/docs/TROUBLESHOOTING.md#dcpoptimizeds3reader-errors) for troubleshooting.
 - `S3FileSystem`: An implementation of PyTorch's FileSystemBase.
 
 These tools enable seamless integration of Amazon S3 with 
@@ -189,25 +190,6 @@ DCP.load(
     storage_reader=s3_storage_reader,
 )
 model.load_state_dict(model_state_dict)
-```
-
-### Troubleshooting DCPOptimizedS3Reader
-
-`S3StorageReader` uses `DCPOptimizedS3Reader` by default (v1.5.0+) for improved performance. See [PR #378 ](https://github.com/awslabs/s3-connector-for-pytorch/pull/378) for more details about the reader. 
-
-If you encounter errors with the default reader, please [submit a GitHub issue](https://github.com/awslabs/s3-connector-for-pytorch/issues) describing your use case. We'd like to understand your scenario and potentially extend `DCPOptimizedS3Reader` to support it, so you can benefit from the performance improvements.
-
-For unsupported or non-DCP access patterns, use the generic reader:
-
-```py
-from s3torchconnector import S3ReaderConstructor
-from s3torchconnector.dcp import S3StorageReader
-
-storage_reader = S3StorageReader(
-    region=REGION, 
-    path=CHECKPOINT_URI,
-    reader_constructor=S3ReaderConstructor.default()
-)
 ```
 
 ## S3 Prefix Strategies for Distributed Checkpointing

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,24 @@
+# Troubleshooting
+
+If `s3torchconnector` is not working as expected, please check [Github issues](https://github.com/awslabs/s3-connector-for-pytorch/issues) to see if your issue has already been addressed. If not, feel free to [create a GitHub issue](https://github.com/awslabs/s3-connector-for-pytorch/issues/new/choose) with all the details.
+
+For debug logging for mountpoint-s3-client and CRT logs, please refer to [Enabling Debug Logging](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/DEVELOPMENT.md#enabling-debug-logging) section in the DEVELOPMENT doc. 
+
+### DCPOptimizedS3Reader Errors
+
+`S3StorageReader` uses `DCPOptimizedS3Reader` (created with `S3ReaderConstructor.dcp_optimized()`) by default (v1.5.0+) for improved performance. See [PR #378](https://github.com/awslabs/s3-connector-for-pytorch/pull/378) for more details about the reader. 
+
+If you encounter errors with the default reader, please [submit a GitHub issue](https://github.com/awslabs/s3-connector-for-pytorch/issues) describing your use case. We'd like to understand your scenario and potentially extend `DCPOptimizedS3Reader` to support it, so you can benefit from the performance improvements.
+
+For unsupported or non-DCP access patterns, use the generic reader:
+
+```py
+from s3torchconnector import S3ReaderConstructor
+from s3torchconnector.dcp import S3StorageReader
+
+storage_reader = S3StorageReader(
+    region=REGION, 
+    path=CHECKPOINT_URI,
+    reader_constructor=S3ReaderConstructor.default()
+)
+```

--- a/s3torchconnector/pyproject.toml
+++ b/s3torchconnector/pyproject.toml
@@ -68,6 +68,7 @@ dcp = [
 dcp-test = [
     "s3torchconnector[dcp]",
     "pytest",
+    "zstandard",
 ]
 
 [tool.setuptools.packages]

--- a/s3torchconnector/src/s3torchconnector/s3reader/constructor.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/constructor.py
@@ -14,7 +14,12 @@ from .protocol import (
 )
 from .sequential import SequentialS3Reader
 from .ranged import RangedS3Reader
-from .dcp_optimized import DCPOptimizedS3Reader, ItemRange, DEFAULT_MAX_GAP_SIZE
+from .dcp_optimized import (
+    DCPOptimizedS3Reader,
+    ItemRange,
+    DEFAULT_MAX_GAP_SIZE,
+    FALLBACK_GUIDANCE,
+)
 
 if TYPE_CHECKING:
     from torch.distributed.checkpoint.planner import ReadItem
@@ -115,7 +120,8 @@ class DCPOptimizedConstructor:
 
         # Error for other files; warn users in case they override prepare_local_plan behavior
         raise ValueError(
-            f"No ranges found for {s3_uri}. Make sure range injection is used in S3StorageReader.prepare_local_plan."
+            f"No ranges found for {s3_uri}. Make sure range injection is used in "
+            f"S3StorageReader.prepare_local_plan.{FALLBACK_GUIDANCE}"
         )
 
 
@@ -135,7 +141,9 @@ class S3ReaderConstructor:
 
     @staticmethod
     def sequential() -> S3ReaderConstructorProtocol:
-        """Creates a constructor for sequential readers
+        """Creates a constructor for sequential (generic) readers.
+
+        This reader is the generic reader that supports all access patterns.
 
         Returns:
             S3ReaderConstructorProtocol: Partial constructor for SequentialS3Reader
@@ -158,8 +166,8 @@ class S3ReaderConstructor:
         Returns:
             S3ReaderConstructorProtocol: Partial constructor for RangedS3Reader
 
-        Range-based reader performs byte-range requests to read specific portions of S3 objects without
-        downloading the entire file.
+        Range-based reader performs byte-range requests for each read/readinto call
+        to read specific portions of S3 objects without downloading the entire file.
 
         Buffer size affects read performance:
 
@@ -233,7 +241,9 @@ class S3ReaderConstructor:
 
     @staticmethod
     def default() -> S3ReaderConstructorProtocol:
-        """Creates default reader constructor (sequential)
+        """Creates the default generic reader constructor.
+
+        This creates a sequential (generic) reader that supports all access patterns.
 
         Returns:
             S3ReaderConstructorProtocol: Partial constructor for SequentialS3Reader

--- a/s3torchconnector/src/s3torchconnector/s3reader/constructor.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/constructor.py
@@ -121,7 +121,7 @@ class DCPOptimizedConstructor:
         # Error for other files; warn users in case they override prepare_local_plan behavior
         raise ValueError(
             f"No ranges found for {s3_uri}. Make sure range injection is used in "
-            f"S3StorageReader.prepare_local_plan.{FALLBACK_GUIDANCE}"
+            f"'S3StorageReader.prepare_local_plan'.\n{FALLBACK_GUIDANCE}"
         )
 
 

--- a/s3torchconnector/src/s3torchconnector/s3reader/dcp_optimized.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/dcp_optimized.py
@@ -48,11 +48,9 @@ FIND_ITEM_ERROR_PREFIX = (
     "DCPOptimizedS3Reader only supports sequentially accessing provided ranges: "
 )
 FALLBACK_GUIDANCE = (
-    "\nIf this error is encountered with the new default reader (S3ReaderConstructor.dcp_optimized()) "
-    "in s3torchconnector v1.5.0, please submit a GitHub issue "
-    "(https://github.com/awslabs/s3-connector-for-pytorch/issues) describing your use case. "
-    "We'd like to understand your scenario and potentially extend DCPOptimizedS3Reader to support it, "
-    "so you can benefit from the performance improvements."
+    "If this error is encountered with the default DCP reader (S3ReaderConstructor.dcp_optimized()) "
+    "added in s3torchconnector v1.5.0, please refer to the troubleshooting doc "
+    "(https://github.com/awslabs/s3-connector-for-pytorch/blob/main/docs/TROUBLESHOOTING.md#dcpoptimizeds3reader-errors)."
     "\nFor unsupported or non-DCP access patterns, use the generic reader: "
     "S3StorageReader(region, path, reader_constructor=S3ReaderConstructor.default())"
 )
@@ -408,7 +406,7 @@ class DCPOptimizedS3Reader(S3Reader):
         if start < item.end or self._current_item_buffer is None:
             raise ValueError(
                 f"{FIND_ITEM_ERROR_PREFIX}Range {start}-{end} not contained in "
-                f"current item {item.start}-{item.end}.{FALLBACK_GUIDANCE}"
+                f"current item {item.start}-{item.end}.\n{FALLBACK_GUIDANCE}"
             )
 
         # Advance to next item
@@ -418,7 +416,7 @@ class DCPOptimizedS3Reader(S3Reader):
         except StopIteration:
             raise ValueError(
                 f"{FIND_ITEM_ERROR_PREFIX}Range {start}-{end} not contained in last item "
-                f"with range {prev_item.start}-{prev_item.end}.{FALLBACK_GUIDANCE}"
+                f"with range {prev_item.start}-{prev_item.end}.\n{FALLBACK_GUIDANCE}"
             )
 
         # Check if requested range is within next item
@@ -428,7 +426,7 @@ class DCPOptimizedS3Reader(S3Reader):
         raise ValueError(
             f"{FIND_ITEM_ERROR_PREFIX}Range {start}-{end} not contained in "
             f"current item {prev_item.start}-{prev_item.end} nor the "
-            f"next item {item.start}-{item.end}.{FALLBACK_GUIDANCE}"
+            f"next item {item.start}-{item.end}.\n{FALLBACK_GUIDANCE}"
         )
 
     def _get_stream_for_item(self, item: ItemRange) -> GetObjectStream:
@@ -657,13 +655,13 @@ class DCPOptimizedS3Reader(S3Reader):
         """
         if size is None:
             raise ValueError(
-                f"Size cannot be None; full read not supported.{FALLBACK_GUIDANCE}"
+                f"Size cannot be None; full read not supported.\n{FALLBACK_GUIDANCE}"
             )
         if not isinstance(size, int):
             raise TypeError(f"argument should be integer or None, not {type(size)!r}")
         if size < 0:
             raise ValueError(
-                f"Size cannot be negative; full read not supported.{FALLBACK_GUIDANCE}"
+                f"Size cannot be negative; full read not supported.\n{FALLBACK_GUIDANCE}"
             )
         if size == 0:
             return b""

--- a/s3torchconnector/src/s3torchconnector/s3reader/dcp_optimized.py
+++ b/s3torchconnector/src/s3torchconnector/s3reader/dcp_optimized.py
@@ -47,6 +47,15 @@ DEFAULT_MAX_GAP_SIZE = (
 FIND_ITEM_ERROR_PREFIX = (
     "DCPOptimizedS3Reader only supports sequentially accessing provided ranges: "
 )
+FALLBACK_GUIDANCE = (
+    "\nIf this error is encountered with the new default reader (S3ReaderConstructor.dcp_optimized()) "
+    "in s3torchconnector v1.5.0, please submit a GitHub issue "
+    "(https://github.com/awslabs/s3-connector-for-pytorch/issues) describing your use case. "
+    "We'd like to understand your scenario and potentially extend DCPOptimizedS3Reader to support it, "
+    "so you can benefit from the performance improvements."
+    "\nFor unsupported or non-DCP access patterns, use the generic reader: "
+    "S3StorageReader(region, path, reader_constructor=S3ReaderConstructor.default())"
+)
 
 
 @dataclass
@@ -399,7 +408,7 @@ class DCPOptimizedS3Reader(S3Reader):
         if start < item.end or self._current_item_buffer is None:
             raise ValueError(
                 f"{FIND_ITEM_ERROR_PREFIX}Range {start}-{end} not contained in "
-                f"current item {item.start}-{item.end}"
+                f"current item {item.start}-{item.end}.{FALLBACK_GUIDANCE}"
             )
 
         # Advance to next item
@@ -409,7 +418,7 @@ class DCPOptimizedS3Reader(S3Reader):
         except StopIteration:
             raise ValueError(
                 f"{FIND_ITEM_ERROR_PREFIX}Range {start}-{end} not contained in last item "
-                f"with range {prev_item.start}-{prev_item.end}"
+                f"with range {prev_item.start}-{prev_item.end}.{FALLBACK_GUIDANCE}"
             )
 
         # Check if requested range is within next item
@@ -419,7 +428,7 @@ class DCPOptimizedS3Reader(S3Reader):
         raise ValueError(
             f"{FIND_ITEM_ERROR_PREFIX}Range {start}-{end} not contained in "
             f"current item {prev_item.start}-{prev_item.end} nor the "
-            f"next item {item.start}-{item.end}."
+            f"next item {item.start}-{item.end}.{FALLBACK_GUIDANCE}"
         )
 
     def _get_stream_for_item(self, item: ItemRange) -> GetObjectStream:
@@ -647,11 +656,15 @@ class DCPOptimizedS3Reader(S3Reader):
             S3Exception: An error occurred accessing S3.
         """
         if size is None:
-            raise ValueError("Size cannot be None; full read not supported")
+            raise ValueError(
+                f"Size cannot be None; full read not supported.{FALLBACK_GUIDANCE}"
+            )
         if not isinstance(size, int):
             raise TypeError(f"argument should be integer or None, not {type(size)!r}")
         if size < 0:
-            raise ValueError("Size cannot be negative; full read not supported")
+            raise ValueError(
+                f"Size cannot be negative; full read not supported.{FALLBACK_GUIDANCE}"
+            )
         if size == 0:
             return b""
 

--- a/s3torchconnector/tst/unit/dcp/test_s3_storage_reader.py
+++ b/s3torchconnector/tst/unit/dcp/test_s3_storage_reader.py
@@ -10,6 +10,7 @@ from torch.distributed.checkpoint.planner import LoadPlan, ReadItem
 
 from s3torchconnector.dcp import S3StorageReader
 from s3torchconnector.s3reader import S3ReaderConstructor, ItemRange
+from s3torchconnector.s3reader.constructor import DCPOptimizedConstructor
 
 TEST_REGION = "eu-east-1"
 TEST_PATH = "s3://test-bucket/test-checkpoint/"
@@ -32,6 +33,12 @@ def load_plan_with_offsets(draw):
         items.append(Mock(spec=ReadItem, storage_index=storage_index))
 
     return LoadPlan(items), storage_data
+
+
+def test_s3storage_reader_default_uses_dcp_optimized():
+    """Verify S3StorageReader without explicit constructor uses dcp_optimized."""
+    reader = S3StorageReader(region=TEST_REGION, path=TEST_PATH)
+    assert isinstance(reader._reader_constructor, DCPOptimizedConstructor)
 
 
 def test_s3storage_reader_prepare_local_plan_empty():


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

This PR makes `S3ReaderConstructor.dcp_optimized()` the default reader constructor for DCP loading with `S3StorageReader`, with additional default/zstandard tests and adding the message from new troubleshooting doc (also shown below), and referred to it in error messages, README, and CHANGELOG. 

#### Message
`S3StorageReader` uses `DCPOptimizedS3Reader` by default (v1.5.0+) for improved performance. See [PR #378 ](https://github.com/awslabs/s3-connector-for-pytorch/pull/378) for more details about the reader. 

If you encounter errors with the default reader, please [submit a GitHub issue](https://github.com/awslabs/s3-connector-for-pytorch/issues) describing your use case. We'd like to understand your scenario and potentially extend `DCPOptimizedS3Reader` to support it, so you can benefit from the performance improvements.

For unsupported or non-DCP access patterns, use the generic reader:

```py
from s3torchconnector import S3ReaderConstructor
from s3torchconnector.dcp import S3StorageReader

storage_reader = S3StorageReader(
    region=REGION, 
    path=CHECKPOINT_URI,
    reader_constructor=S3ReaderConstructor.default()
)
```

#### Changes:
- Change S3StorageReader default from S3ReaderConstructor.default() to S3ReaderConstructor.dcp_optimized()
- Adjust docs and error messages
  - New TROUBLESHOOTING.md doc with message (similar to above). 
  - Add FALLBACK_GUIDANCE to error messages with TROUBLESHOOTING.md doc link and fallback instructions
  - Update README pointing to TROUBLESHOOTING.md doc in DCP section and simplified DCP examples
  - Update CHANGELOG with soft breaking change documentation, also pointing to TROUBLESHOOTING.md
- Adjust tests
  - Add unit test for default constructor verification
  - Zstandard tests (see additional context for explanation)
    - Add zstandard to dcp-test dependencies
    - Add e2e test for ZStandard compression with all reader types

## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

### ZStandard

To make DCPOptimizedS3Reader default I'm also testing its compatibility with [`transform_from` line in PyTorch DCP `filesystem.py`](https://github.com/pytorch/pytorch/blob/8bbfb71691b68ed3458292ba67cb02eece869468/torch/distributed/checkpoint/filesystem.py#L876) with `_extensions=[ZStandard()],` on S3StorageWriter, which _"implements the [transform_to()](https://github.com/pytorch/pytorch/blob/1258aac1c28f2e66f54ecacaf798a0e7a24206ef/torch/distributed/checkpoint/_extension.py#L121C5-L146C47) to compress the outgoing stream data and the [transform_from()](https://github.com/pytorch/pytorch/blob/1258aac1c28f2e66f54ecacaf798a0e7a24206ef/torch/distributed/checkpoint/_extension.py#L148C5-L186C46) to decompress the incoming stream data"_ [[Source: ZStandard blog post]]( https://pytorch.org/blog/reducing-storage-footprint-and-bandwidth-usage-for-distributed-checkpoints-with-pytorch-dcp/)

The package https://pypi.org/project/zstandard/ is added to `dcp-test` extra for these tests.

Note Python 3.8 does not have ZStandard - to edit in https://github.com/awslabs/s3-connector-for-pytorch/pull/390. 
```
❯ python3.9 -c "from torch.distributed.checkpoint._extension import ZStandard"
❯ python3.8 -c "from torch.distributed.checkpoint._extension import ZStandard"
ModuleNotFoundError: No module named 'torch.distributed.checkpoint._extension'
```

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->
- https://github.com/awslabs/s3-connector-for-pytorch/pull/378

## Testing
<!-- Please describe how these changes were tested. -->
Tests/Integration tests pass.
[Build Wheels Workflow](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/22156975720) also verifies these changes still allow Build Wheels tests to pass with the new `zstandard` package being imported correctly for all architectures. (this run only has minor docs edits from current PR).

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
