### PR TITLE
Add S3 endpoint support to s3torchbenchmarking

### DIFF
--- a/s3torchbenchmarking/conf/dataset.yaml
+++ b/s3torchbenchmarking/conf/dataset.yaml
@@ -8,6 +8,7 @@ defaults:
 s3:
   region: ??? # e.g., eu-west-1
   bucket: ??? # e.g., my-bucket (*not* an S3 URI)
+  endpoint: null # optional: custom S3-compatible endpoint URL
 # Boolean flag to tell whether the dataset is sharded or not.
 sharding: True
 # Number of iterations for training a model.

--- a/s3torchbenchmarking/conf/dataset.yaml
+++ b/s3torchbenchmarking/conf/dataset.yaml
@@ -9,6 +9,7 @@ s3:
   region: ??? # e.g., eu-west-1
   bucket: ??? # e.g., my-bucket (*not* an S3 URI)
   endpoint: null # optional: custom S3-compatible endpoint URL
+  force_path_style: false # use path-style addressing (required for most S3-compatible services)
 # Boolean flag to tell whether the dataset is sharded or not.
 sharding: True
 # Number of iterations for training a model.

--- a/s3torchbenchmarking/src/s3torchbenchmarking/datagen.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/datagen.py
@@ -118,9 +118,15 @@ class Utils:
             return int(width), int(height)
 
     @staticmethod
-    def upload_to_s3(region: str, data: io.BytesIO, bucket: str, key: str):
+    def upload_to_s3(
+        region: str, data: io.BytesIO, bucket: str, key: str,
+        endpoint: Optional[str] = None,
+    ):
         click.echo(f"Uploading to {key=}")
-        s3_client = boto3.client("s3", region_name=region)
+        client_kwargs = {"region_name": region}
+        if endpoint:
+            client_kwargs["endpoint_url"] = endpoint
+        s3_client = boto3.client("s3", **client_kwargs)
         s3_client.upload_fileobj(data, bucket, key)
 
     @staticmethod
@@ -205,7 +211,8 @@ def build_producers(
 
 
 def build_consumers(
-    num_workers: int, queue: Queue, disambiguator: str, region: str, s3_bucket: str
+    num_workers: int, queue: Queue, disambiguator: str, region: str, s3_bucket: str,
+    endpoint: Optional[str] = None,
 ) -> List[Thread]:
     return [
         Thread(
@@ -218,6 +225,7 @@ def build_consumers(
                     data=sample.data,
                     bucket=s3_bucket,
                     key=f"{disambiguator}/{sample.label}",
+                    endpoint=endpoint,
                 ),
             },
         )
@@ -293,6 +301,12 @@ def consumer(queue: Queue, activity: Callable[[Union[LabelledSample, Sentinel]],
     type=str,
     help="Region where the S3 bucket is hosted.",
 )
+@click.option(
+    "--endpoint",
+    default=None,
+    type=str,
+    help="Custom S3-compatible endpoint URL.",
+)
 def synthesize_dataset(
     num_samples: float,
     resolution: Tuple[int, int],
@@ -301,6 +315,7 @@ def synthesize_dataset(
     s3_bucket: str,
     s3_prefix: str,
     region: str,
+    endpoint: Optional[str],
 ):
     """Synthesizes a dataset that will be used for s3torchbenchmarking and uploads it to an S3 bucket."""
     num_workers = os.cpu_count() or 1
@@ -329,6 +344,7 @@ def synthesize_dataset(
         disambiguator=disambiguator,
         region=region,
         s3_bucket=s3_bucket,
+        endpoint=endpoint,
     )
 
     # kick off consumers and producers

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -19,7 +19,7 @@ from s3torchbenchmarking.models import (
     ViT,
     ModelInterface,
 )
-from s3torchconnector import S3MapDataset, S3Reader, S3IterableDataset
+from s3torchconnector import S3MapDataset, S3Reader, S3IterableDataset, S3ClientConfig
 from s3torchconnector.s3reader import S3ReaderConstructor, S3ReaderConstructorProtocol
 from s3torchconnector._s3dataset_common import parse_s3_uri  # type: ignore
 
@@ -34,12 +34,14 @@ def run_experiment(config: DictConfig) -> dict:
     )
 
     endpoint = config.s3.get("endpoint")
+    force_path_style = config.s3.get("force_path_style", False)
     dataset = make_dataset(
         dataloader_config=config.dataloader,
         sharding=config.sharding,
         prefix_uri=fully_qualified_uri,
         region=config.s3.region,
         endpoint=endpoint,
+        force_path_style=force_path_style,
         load_sample=model.load_sample,
     )
     dataloader = make_dataloader(
@@ -74,6 +76,7 @@ def make_mountpoint(
     mountpoint_path: Optional[str] = None,
     additional_args: Optional[List[str]] = None,
     endpoint: Optional[str] = None,
+    force_path_style: bool = False,
 ) -> str:
     def teardown(path: str):
         subprocess.run(["sudo", "umount", path])
@@ -85,7 +88,9 @@ def make_mountpoint(
     binary = mountpoint_path or "mount-s3"
     args = additional_args or []
     if endpoint:
-        args = ["--endpoint-url", endpoint, "--force-path-style"] + args
+        args = ["--endpoint-url", endpoint] + args
+    if force_path_style:
+        args = ["--force-path-style"] + args
     subprocess.run([binary, bucket, tempdir] + args, check=True)
     atexit.register(teardown, tempdir)
 
@@ -101,6 +106,7 @@ def make_dataset(
     load_sample,
     *,
     endpoint: Optional[str] = None,
+    force_path_style: bool = False,
 ) -> Dataset:
 
     kind = dataloader_config.kind
@@ -120,6 +126,7 @@ def make_dataset(
             num_workers,
             s3reader_config,
             endpoint=endpoint,
+            force_path_style=force_path_style,
         )
     if kind == "s3mapdataset":
         if not region:
@@ -130,18 +137,22 @@ def make_dataset(
         return create_s3_map_dataset(
             sharding, prefix_uri, region, load_sample, s3reader_config,
             endpoint=endpoint,
+            force_path_style=force_path_style,
         )
     if kind == "fsspec":
         return create_fsspec_dataset(
-            sharding, prefix_uri, load_sample, num_workers, endpoint=endpoint
+            sharding, prefix_uri, load_sample, num_workers,
+            endpoint=endpoint, force_path_style=force_path_style,
         )
     if kind == "mountpoint":
         return create_mountpoint_dataset(
-            sharding, prefix_uri, load_sample, num_workers, False, endpoint=endpoint
+            sharding, prefix_uri, load_sample, num_workers, False,
+            endpoint=endpoint, force_path_style=force_path_style,
         )
     if kind == "mountpointcache":
         return create_mountpoint_dataset(
-            sharding, prefix_uri, load_sample, num_workers, True, endpoint=endpoint
+            sharding, prefix_uri, load_sample, num_workers, True,
+            endpoint=endpoint, force_path_style=force_path_style,
         )
     raise Exception(f"Unknown dataset kind {kind}")
 
@@ -174,10 +185,13 @@ def create_s3_iterable_dataset(
     num_workers: int,
     s3reader_config: DictConfig,
     endpoint: Optional[str] = None,
+    force_path_style: bool = False,
 ):
     reader_constructor = make_s3_reader_constructor(s3reader_config)
+    s3client_config = S3ClientConfig(force_path_style=force_path_style)
     dataset = S3IterableDataset.from_prefix(
         prefix_uri, region=region, endpoint=endpoint,
+        s3client_config=s3client_config,
         reader_constructor=reader_constructor,
     )
     dataset = torchdata.datapipes.iter.IterableWrapper(dataset)
@@ -198,8 +212,10 @@ def create_s3_map_dataset(
     load_sample,
     s3reader_config: DictConfig,
     endpoint: Optional[str] = None,
+    force_path_style: bool = False,
 ):
     reader_constructor = make_s3_reader_constructor(s3reader_config)
+    s3client_config = S3ClientConfig(force_path_style=force_path_style)
     if sharding:
         raise ValueError("Sharding is not supported for s3mapdataset")
     else:
@@ -207,6 +223,7 @@ def create_s3_map_dataset(
             prefix_uri,
             region=region,
             endpoint=endpoint,
+            s3client_config=s3client_config,
             transform=load_sample,
             reader_constructor=reader_constructor,
         )
@@ -215,7 +232,7 @@ def create_s3_map_dataset(
 
 def create_mountpoint_dataset(
     sharding: bool, prefix_uri: str, load_sample, num_workers: int, use_cache: bool,
-    endpoint: Optional[str] = None,
+    endpoint: Optional[str] = None, force_path_style: bool = False,
 ):
     if use_cache:
         cache_dir = tempfile.mkdtemp(dir="./nvme/", prefix="s3mp_cache_")
@@ -224,7 +241,8 @@ def create_mountpoint_dataset(
         arguments = ["--metadata-ttl", "indefinite"]
 
     prefix_uri = make_mountpoint(
-        prefix_uri=prefix_uri, additional_args=arguments, endpoint=endpoint
+        prefix_uri=prefix_uri, additional_args=arguments,
+        endpoint=endpoint, force_path_style=force_path_style,
     )
     # TODO: compare the performance of using torchdata file APIs and use the more performant option.
     return create_fsspec_dataset(sharding, prefix_uri, load_sample, num_workers)
@@ -232,11 +250,13 @@ def create_mountpoint_dataset(
 
 def create_fsspec_dataset(
     sharding: bool, prefix_uri: str, load_sample, num_workers: int,
-    endpoint: Optional[str] = None,
+    endpoint: Optional[str] = None, force_path_style: bool = False,
 ):
     fsspec_kwargs = {}
     if endpoint:
         fsspec_kwargs["client_kwargs"] = {"endpoint_url": endpoint}
+    if force_path_style:
+        fsspec_kwargs["config_kwargs"] = {"s3": {"addressing_style": "path"}}
     lister = torchdata.datapipes.iter.FSSpecFileLister(prefix_uri, **fsspec_kwargs)
     dataset = torchdata.datapipes.iter.FSSpecFileOpener(lister, mode="rb", **fsspec_kwargs)
     if num_workers > 0:

--- a/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
+++ b/s3torchbenchmarking/src/s3torchbenchmarking/dataset/benchmark.py
@@ -33,11 +33,13 @@ def run_experiment(config: DictConfig) -> dict:
         "s3://" + config.s3.bucket.strip("/") + "/" + config.dataset.strip("/")
     )
 
+    endpoint = config.s3.get("endpoint")
     dataset = make_dataset(
         dataloader_config=config.dataloader,
         sharding=config.sharding,
         prefix_uri=fully_qualified_uri,
         region=config.s3.region,
+        endpoint=endpoint,
         load_sample=model.load_sample,
     )
     dataloader = make_dataloader(
@@ -71,6 +73,7 @@ def make_mountpoint(
     prefix_uri: str,
     mountpoint_path: Optional[str] = None,
     additional_args: Optional[List[str]] = None,
+    endpoint: Optional[str] = None,
 ) -> str:
     def teardown(path: str):
         subprocess.run(["sudo", "umount", path])
@@ -81,6 +84,8 @@ def make_mountpoint(
     tempdir = tempfile.mkdtemp(prefix="s3dataset_")
     binary = mountpoint_path or "mount-s3"
     args = additional_args or []
+    if endpoint:
+        args = ["--endpoint-url", endpoint, "--force-path-style"] + args
     subprocess.run([binary, bucket, tempdir] + args, check=True)
     atexit.register(teardown, tempdir)
 
@@ -94,6 +99,8 @@ def make_dataset(
     prefix_uri: str,
     region: Optional[str],
     load_sample,
+    *,
+    endpoint: Optional[str] = None,
 ) -> Dataset:
 
     kind = dataloader_config.kind
@@ -112,6 +119,7 @@ def make_dataset(
             load_sample,
             num_workers,
             s3reader_config,
+            endpoint=endpoint,
         )
     if kind == "s3mapdataset":
         if not region:
@@ -120,17 +128,20 @@ def make_dataset(
             raise ValueError(f"Must provide s3reader config for {kind}")
         s3reader_config = dataloader_config.s3reader
         return create_s3_map_dataset(
-            sharding, prefix_uri, region, load_sample, s3reader_config
+            sharding, prefix_uri, region, load_sample, s3reader_config,
+            endpoint=endpoint,
         )
     if kind == "fsspec":
-        return create_fsspec_dataset(sharding, prefix_uri, load_sample, num_workers)
+        return create_fsspec_dataset(
+            sharding, prefix_uri, load_sample, num_workers, endpoint=endpoint
+        )
     if kind == "mountpoint":
         return create_mountpoint_dataset(
-            sharding, prefix_uri, load_sample, num_workers, False
+            sharding, prefix_uri, load_sample, num_workers, False, endpoint=endpoint
         )
     if kind == "mountpointcache":
         return create_mountpoint_dataset(
-            sharding, prefix_uri, load_sample, num_workers, True
+            sharding, prefix_uri, load_sample, num_workers, True, endpoint=endpoint
         )
     raise Exception(f"Unknown dataset kind {kind}")
 
@@ -162,10 +173,12 @@ def create_s3_iterable_dataset(
     load_sample,
     num_workers: int,
     s3reader_config: DictConfig,
+    endpoint: Optional[str] = None,
 ):
     reader_constructor = make_s3_reader_constructor(s3reader_config)
     dataset = S3IterableDataset.from_prefix(
-        prefix_uri, region=region, reader_constructor=reader_constructor
+        prefix_uri, region=region, endpoint=endpoint,
+        reader_constructor=reader_constructor,
     )
     dataset = torchdata.datapipes.iter.IterableWrapper(dataset)
 
@@ -184,6 +197,7 @@ def create_s3_map_dataset(
     region: str,
     load_sample,
     s3reader_config: DictConfig,
+    endpoint: Optional[str] = None,
 ):
     reader_constructor = make_s3_reader_constructor(s3reader_config)
     if sharding:
@@ -192,6 +206,7 @@ def create_s3_map_dataset(
         dataset = S3MapDataset.from_prefix(
             prefix_uri,
             region=region,
+            endpoint=endpoint,
             transform=load_sample,
             reader_constructor=reader_constructor,
         )
@@ -199,7 +214,8 @@ def create_s3_map_dataset(
 
 
 def create_mountpoint_dataset(
-    sharding: bool, prefix_uri: str, load_sample, num_workers: int, use_cache: bool
+    sharding: bool, prefix_uri: str, load_sample, num_workers: int, use_cache: bool,
+    endpoint: Optional[str] = None,
 ):
     if use_cache:
         cache_dir = tempfile.mkdtemp(dir="./nvme/", prefix="s3mp_cache_")
@@ -207,16 +223,22 @@ def create_mountpoint_dataset(
     else:
         arguments = ["--metadata-ttl", "indefinite"]
 
-    prefix_uri = make_mountpoint(prefix_uri=prefix_uri, additional_args=arguments)
+    prefix_uri = make_mountpoint(
+        prefix_uri=prefix_uri, additional_args=arguments, endpoint=endpoint
+    )
     # TODO: compare the performance of using torchdata file APIs and use the more performant option.
     return create_fsspec_dataset(sharding, prefix_uri, load_sample, num_workers)
 
 
 def create_fsspec_dataset(
-    sharding: bool, prefix_uri: str, load_sample, num_workers: int
+    sharding: bool, prefix_uri: str, load_sample, num_workers: int,
+    endpoint: Optional[str] = None,
 ):
-    lister = torchdata.datapipes.iter.FSSpecFileLister(prefix_uri)
-    dataset = torchdata.datapipes.iter.FSSpecFileOpener(lister, mode="rb")
+    fsspec_kwargs = {}
+    if endpoint:
+        fsspec_kwargs["client_kwargs"] = {"endpoint_url": endpoint}
+    lister = torchdata.datapipes.iter.FSSpecFileLister(prefix_uri, **fsspec_kwargs)
+    dataset = torchdata.datapipes.iter.FSSpecFileOpener(lister, mode="rb", **fsspec_kwargs)
     if num_workers > 0:
         dataset = dataset.sharding_filter()
     if sharding:


### PR DESCRIPTION
## Description

Add support for custom S3-compatible endpoints to the s3torchbenchmarking tool. The underlying s3torchconnector library already supports custom endpoints via an `endpoint` parameter, but the benchmarking tool never passed this configuration through. This change enables using the benchmarking suite against any S3-compatible storage service.

## Additional context

No breaking changes. The endpoint parameter is optional and defaults to None throughout, preserving existing AWS S3 behavior.

- [ ] I have updated the CHANGELOG or README if appropriate

## Testing

The existing smoke test (module imports) passes.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).