### PR TITLE
fix(config): validate max_attempts in S3ClientConfig to avoid opaque Rust panic

### DIFF
--- a/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
+++ b/s3torchconnector/src/s3torchconnector/_s3client/s3client_config.py
@@ -3,6 +3,15 @@
 from dataclasses import dataclass
 from typing import Optional
 
+# Upper bound for `max_attempts`, enforced Python-side to avoid an opaque
+# pyo3_runtime.PanicException raised from inside the Rust client constructor
+# (see issue #361). The AWS CRT retry strategy uses exponential backoff and
+# rejects attempt counts above this limit. The exact value is a CRT-internal
+# constant; 63 matches the value cited by the maintainer. It is centralized
+# here so it can be adjusted in one place if the CRT limit is confirmed to
+# differ.
+_MAX_ATTEMPTS_LIMIT = 63
+
 
 @dataclass(frozen=True)
 class S3ClientConfig:
@@ -28,3 +37,18 @@ class S3ClientConfig:
     force_path_style: bool = False
     max_attempts: int = 10
     profile: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        # Validate `max_attempts` here so that invalid values raise a clear,
+        # catchable ValueError instead of an opaque pyo3_runtime.PanicException
+        # from inside the Rust client constructor (see issue #361). The Rust
+        # side calls NonZeroUsize::try_from(max_attempts).expect(...) (panics on
+        # 0) and the AWS CRT retry strategy panics on values above its
+        # exponential-backoff limit.
+        if self.max_attempts < 1:
+            raise ValueError("max_attempts must be a positive integer")
+        if self.max_attempts > _MAX_ATTEMPTS_LIMIT:
+            raise ValueError(
+                f"max_attempts must be between 1 and {_MAX_ATTEMPTS_LIMIT} "
+                "(AWS CRT retry-strategy limit)"
+            )

--- a/s3torchconnector/tst/unit/test_s3_client_config.py
+++ b/s3torchconnector/tst/unit/test_s3_client_config.py
@@ -1,9 +1,11 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  // SPDX-License-Identifier: BSD
+import pytest
 from hypothesis import given, example
 from hypothesis.strategies import integers, floats
 
 from s3torchconnector import S3ClientConfig
+from s3torchconnector._s3client.s3client_config import _MAX_ATTEMPTS_LIMIT
 from .test_s3_client import MiB, GiB
 
 
@@ -44,6 +46,32 @@ def test_throughput_target_gbps_setup(throughput_target_gbps: float):
 def test_max_attempts_setup(max_attempts: int):
     config = S3ClientConfig(max_attempts=max_attempts)
     assert config.max_attempts == max_attempts
+
+
+@given(max_attempts=integers(min_value=1, max_value=_MAX_ATTEMPTS_LIMIT))
+def test_max_attempts_valid_range(max_attempts: int):
+    config = S3ClientConfig(max_attempts=max_attempts)
+    assert config.max_attempts == max_attempts
+
+
+def test_max_attempts_zero_raises():
+    # See issue #361: max_attempts=0 panics inside the Rust constructor
+    # (NonZeroUsize::try_from(...).expect("max_attempts must be > 0")) as an
+    # uncatchable pyo3_runtime.PanicException. Guard it in pure Python instead.
+    with pytest.raises(ValueError):
+        S3ClientConfig(max_attempts=0)
+
+
+def test_max_attempts_negative_raises():
+    with pytest.raises(ValueError):
+        S3ClientConfig(max_attempts=-1)
+
+
+def test_max_attempts_above_cap_raises():
+    # See issue #361: values above the AWS CRT exponential-backoff retry-strategy
+    # limit panic inside the Rust constructor; reject them clearly in Python.
+    with pytest.raises(ValueError):
+        S3ClientConfig(max_attempts=_MAX_ATTEMPTS_LIMIT + 1)
 
 
 @given(


### PR DESCRIPTION
## Problem

`S3ClientConfig(max_attempts=N)` with an out-of-range `N` crashes with an opaque `pyo3_runtime.PanicException` raised from inside the Rust client constructor. Because the panic crosses the PyO3/FFI boundary, it is **not catchable as a normal Python exception**, so callers cannot defend against it cleanly.

- `max_attempts=0` panics via Rust `NonZeroUsize::try_from(...).expect("max_attempts must be > 0")`.
- `max_attempts` above the AWS CRT exponential-backoff retry-strategy cap panics inside the CRT.

## Root cause

`s3torchconnector/_s3client/s3client_config.py` defines `S3ClientConfig` as a `@dataclass(frozen=True)` with **no validation**. Invalid values fall straight through the pure-Python layer into the Rust constructor, where they panic.

## Fix

Add a `__post_init__` guard that validates `max_attempts` at construction time and raises a clear, catchable `ValueError` instead of letting it reach the Rust panic:

- `max_attempts < 1` → `ValueError("max_attempts must be a positive integer")`
- `max_attempts > _MAX_ATTEMPTS_LIMIT` → `ValueError("max_attempts must be between 1 and 63 (AWS CRT retry-strategy limit)")`

**⚠️ Maintainer confirmation requested on the upper bound:** the exact cap is a CRT-internal constant. I've set `_MAX_ATTEMPTS_LIMIT = 63` as a single, clearly-commented module constant so it's trivial to adjust. **If you'd prefer to be conservative, I'm happy to ship only the lower-bound guard** (`< 1`, zero risk since the Rust side already rejects 0) and drop the upper bound — just let me know.

## Testing

Added to `tst/unit/test_s3_client_config.py`: a hypothesis property test `@given(integers(min_value=1, max_value=63))` confirming valid values construct fine, plus `test_max_attempts_zero_raises`, `test_max_attempts_negative_raises`, and `test_max_attempts_above_cap_raises`. Validated TDD-style (fail before, pass after).

## Risk

Low. Pure-Python, additive validation in a frozen dataclass (reads fields only). The lower-bound guard is zero-risk; the only judgment call is the exact upper-bound value, isolated to one adjustable constant.

Fixes #361
