### PR TITLE
build(deps): bump pyo3 to 0.29.0 and address breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## TBD
+
+### New features
+
+### Bug fixes
+
+### Other changes
+* Bump PyO3 from 0.27.2 to 0.29.0
+
+### Breaking changes
+
 ## v1.5.0 (February 20, 2026)
 
 ### New features

--- a/s3torchconnectorclient/Cargo.lock
+++ b/s3torchconnectorclient/Cargo.lock
@@ -632,12 +632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,15 +750,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "metrics"
@@ -992,35 +977,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1028,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1040,13 +1022,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1320,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -1507,12 +1488,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "url"

--- a/s3torchconnectorclient/Cargo.toml
+++ b/s3torchconnectorclient/Cargo.toml
@@ -16,7 +16,7 @@ path = "rust/src/lib.rs"
 built = "0.7"
 
 [dependencies]
-pyo3 = "0.27.2"
+pyo3 = "0.29.0"
 futures = "0.3.28"
 mountpoint-s3-client = { version = "0.14.1", features = ["mock"] }
 mountpoint-s3-crt-sys = { version = "0.13.0" }

--- a/s3torchconnectorclient/rust/src/mock_client.rs
+++ b/s3torchconnectorclient/rust/src/mock_client.rs
@@ -14,7 +14,8 @@ use crate::MountpointS3Client;
 #[pyclass(
     name = "MockMountpointS3Client",
     module = "s3torchconnectorclient._mountpoint_s3_client",
-    frozen
+    frozen,
+    skip_from_py_object
 )]
 pub struct PyMockClient {
     mock_client: Arc<MockClient>,

--- a/s3torchconnectorclient/rust/src/python_structs/py_head_object_result.rs
+++ b/s3torchconnectorclient/rust/src/python_structs/py_head_object_result.rs
@@ -16,7 +16,8 @@ use crate::PyRef;
 #[pyclass(
     name = "HeadObjectResult",
     module = "s3torchconnectorclient._mountpoint_s3_client",
-    frozen
+    frozen,
+    skip_from_py_object
 )]
 #[derive(Debug, Clone)]
 pub struct PyHeadObjectResult {

--- a/s3torchconnectorclient/rust/src/python_structs/py_object_info.rs
+++ b/s3torchconnectorclient/rust/src/python_structs/py_object_info.rs
@@ -15,7 +15,8 @@ use crate::PyRef;
 #[pyclass(
     name = "ObjectInfo",
     module = "s3torchconnectorclient._mountpoint_s3_client",
-    frozen
+    frozen,
+    skip_from_py_object
 )]
 #[derive(Debug, Clone)]
 pub struct PyObjectInfo {

--- a/s3torchconnectorclient/rust/src/python_structs/py_restore_status.rs
+++ b/s3torchconnectorclient/rust/src/python_structs/py_restore_status.rs
@@ -13,7 +13,8 @@ use crate::PyRef;
 
 #[pyclass(
     name = "RestoreStatus",
-    module = "s3torchconnectorclient._mountpoint_s3_client"
+    module = "s3torchconnectorclient._mountpoint_s3_client",
+    from_py_object
 )]
 #[derive(Debug, Clone)]
 pub struct PyRestoreStatus {


### PR DESCRIPTION
## Description
<!-- Thank you for submitting a pull request! Find more information in our development guide at [DEVELOPMENT](DEVELOPMENT.md) -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

Changes:
- Bumps pyo3 from 0.27.2 to 0.29.0
- For each of 4 affected `#[pyclass] + #[derive(Clone)]`, annotate with `skip_from_py_object` if the type is never used as a Python function argument, and use `from_py_object` for the remaining one (`RestoreStatus`) (see additional context for more details).

This addresses the breaking change that https://github.com/awslabs/s3-connector-for-pytorch/pull/429 failed to resolve: 
- https://pyo3.rs/v0.29.0/migration#deprecation-of-automatic-frompyobject-for-pyclass-types-which-implement-clone (expand that section to view)

Note: I have not run cargo fmt and only implemented required changes to avoid making this PR noisy - we could do it in subsequent PRs (we don't have a process on doing that nor checking for rust code style yet)


## Additional context
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
<!-- Please confirm there is no breaking change, or call out any behavior changes you think are necessary. -->

[Rust Checks / Licenses (advisories)](https://github.com/awslabs/s3-connector-for-pytorch/actions/runs/28350848549/job/83983220433?pr=433#logs) are failing. This PR unblocks our CI. 

Copying from the [migration guide](https://pyo3.rs/v0.29.0/migration#deprecation-of-automatic-frompyobject-for-pyclass-types-which-implement-clone) directly:

<details>

<summary> (Click to expand) Deprecation of automatic FromPyObject for #[pyclass] types which implement Clone </summary>

`#[pyclass]` types which implement `Clone` used to also implement `FromPyObject` automatically. This behavior is being phased out and replaced by an explicit opt-in, which will allow [better error messages and more user control](https://github.com/PyO3/pyo3/issues/5419). Affected types will by marked by a deprecation message.

To migrate use either

```rs
#[pyclass(from_py_object)] to keep the automatic derive, or
#[pyclass(skip_from_py_object)] to accept the new behavior.

```

Before:

```rs
#[pyclass]
#[derive(Clone)]
struct PyClass {}

```
After:

```rs
// If the automatic implementation of `FromPyObject` is desired, opt in:
#[pyclass(from_py_object)]
#[derive(Clone)]
struct PyClass {}

// or if the `FromPyObject` implementation is not needed:
#[pyclass(skip_from_py_object)]
#[derive(Clone)]
struct PyClassWithoutFromPyObject {}
```

The `#[pyclass(skip_from_py_object)]` option will eventually be deprecated and removed as it becomes the default behavior.

</details>

In py_object_info.rs and py_head_object_result.rs python passes `restore_status: Option<PyRestoreStatus>` in so we need `from_py_object`, example from py_object_info.rs:
```rs
#[pymethods]
impl PyObjectInfo {
    #[new]
    #[pyo3(signature = (key, etag, size, last_modified, storage_class=None, restore_status=None))]
    pub fn new(
        key: String,
        etag: String,
        size: u64,
        last_modified: i64,
        storage_class: Option<String>,
        restore_status: Option<PyRestoreStatus>,
    ) -> Self {
...
```

- [x] I have updated the CHANGELOG or README if appropriate

## Related items
<!-- Please add related pull requests or Github issues. -->

- https://github.com/awslabs/s3-connector-for-pytorch/pull/429

## Testing
<!-- Please describe how these changes were tested. -->

`s3torchconnectorclient` builds, and unit tests pass. Integration tests will run in this PR.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
