### PR TITLE
Enable Jinja2 autoescape in HtmlResultGenerator

### DIFF
--- a/s3torchbenchmarking/utils/html_result_generator.py
+++ b/s3torchbenchmarking/utils/html_result_generator.py
@@ -1,4 +1,5 @@
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from markupsafe import Markup
 from typing import Any, Dict, List
 
 
@@ -58,7 +59,13 @@ class HtmlResultGenerator:
 """
 
     def __init__(self):
-        self.env = Environment(loader=FileSystemLoader("."))
+        self.env = Environment(
+            loader=FileSystemLoader("."),
+            autoescape=select_autoescape(
+                enabled_extensions=("html",),
+                default_for_string=True,
+            ),
+        )
         self.template = self.env.from_string(self.html_result_template)
 
     def get_cell(self, records, row_index, field_names, field, span_indexes):
@@ -66,11 +73,13 @@ class HtmlResultGenerator:
         if row_index < len(records):
             cell_position = row_index * len(field_names) + field_index
             if span_indexes[cell_position] == 0:
-                return ""
+                return Markup("")
             if span_indexes[cell_position] == 1:
-                return f"<td>{records[row_index][field]}</td>"
-            return f'<td rowspan="{span_indexes[cell_position]}">{records[row_index][field]}</td>'
-        return ""
+                return Markup("<td>{}</td>").format(records[row_index][field])
+            return Markup('<td rowspan="{}">{}</td>').format(
+                span_indexes[cell_position], records[row_index][field]
+            )
+        return Markup("")
 
     def generate_html(
         self,


### PR DESCRIPTION
## Description
Enable Jinja2 autoescaping in `HtmlResultGenerator` (`s3torchbenchmarking/utils/html_result_generator.py`).

The Jinja2 `Environment` was created without autoescaping, which is disabled by default. This makes the generated benchmark HTML report susceptible to unescaped values being rendered as markup. This change configures the environment with `select_autoescape(...)` so rendered values are HTML-escaped.

Because `get_cell()` intentionally returns `<td>` markup that is injected via `{{ ... }}`, its output is now wrapped in `markupsafe.Markup` so the table structure still renders correctly while the underlying data values remain escaped.

## Additional context
- No behavior change to the benchmarking workflow: the generated report renders the same for normal data.
- The only functional effect is that data values are now HTML-escaped in the output, which is the intended, safer behavior.
- Scope is limited to the benchmarking utility (`s3torchbenchmarking`), which is not production code.

- [ ] I have updated the CHANGELOG or README if appropriate

## Testing
Verified locally against the generator:
- Normal input still produces a valid `<table>` with the expected `<td>` cells and values.
- An injected value of `<script>alert(1)</script>` is escaped in the output (`&lt;script&gt;...`) rather than rendered as live markup.

--------
By submitting this pull request, I confirm that my contribution is made under the terms of BSD 3-Clause License and I agree to the terms of the [LICENSE](https://github.com/awslabs/s3-connector-for-pytorch/blob/main/LICENSE).
